### PR TITLE
fix empty excerpts

### DIFF
--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -1,0 +1,18 @@
+<article class="post {{ .Section }}">
+    <header class="post-header">
+        <h2 class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+    </header>
+    <section class="post-excerpt">
+        <p>{{ .Summary | markdownify | plainify | htmlUnescape | default "Read More"}} <a class="read-more" href="{{.RelPermalink}}">&raquo;</a></p>
+    </section>
+    <footer class=" footline" >
+        {{- with .Params.LastModifierDisplayName -}}
+            <i class='fa fa-user'></i> <a href="mailto:{{ $.Params.LastModifierEmail }}">{{ . }}</a> {{with $.Date}} <i class='fa fa-calendar'></i> {{ .Format "02/01/2006" }}{{end}}
+        {{- end -}}
+        {{- if .Params.tags -}}  
+            {{ range $index, $tag := .Params.tags }}
+                <a class="label label-default" href="{{$.Site.BaseURL}}tags/{{ $tag | urlize }}/">{{ $tag }}</a>
+            {{ end }}
+        {{- end -}}
+    </footer>
+</article>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -20,6 +20,10 @@ body > header {
   padding-right: 10%;
 }
 
+body > header a {
+  color: rgba(255,255,255,0.8);
+}
+
 body > header:after { 
   display: none;
 }


### PR DESCRIPTION
## what
* CSS bug led to top nav links disappearing
* truncate whitespace on excerpts so they can be hidden with css
* normalize excerpts so they look pretty (slows hugo down 3x)