### PR TITLE
Only deploy on tagged releases to `master` branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ build-harness/
 public/*
 .gitkeep
 *.swp
+.idea
+*.iml
+package-lock.json

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -10,6 +10,16 @@ steps:
       - cf_export BUILD_HARNESS_VERSION=0.5.5
       - cf_export HUGO_CONFIG=deploy.toml
 
+  semver:
+    title: Export semantic version
+    image: cloudposse/build-harness:${{BUILD_HARNESS_VERSION}}
+    working_directory: ./
+    commands:
+      - make git/show
+      - make git/export | tee -a ${{CF_VOLUME_PATH}}/env_vars_to_export
+      - make semver/show
+      - make semver/export | tee -a ${{CF_VOLUME_PATH}}/env_vars_to_export
+
   build:
     title: Building Hugo static site...
     image: cloudposse/build-harness:${{BUILD_HARNESS_VERSION}}
@@ -37,6 +47,7 @@ steps:
       condition:
         all:
           executeForMasterBranch: "'${{CF_BRANCH}}' == '${{MASTER_BRANCH}}'"
+          executeForTag: "'${{SEMVERSION_TAG}}' != ''"
 
   reindex:
     title: Updating algolia search index...
@@ -48,3 +59,4 @@ steps:
       condition:
         all:
           executeForMasterBranch: "'${{CF_BRANCH}}' == '${{MASTER_BRANCH}}'"
+          executeForTag: "'${{SEMVERSION_TAG}}' != ''"


### PR DESCRIPTION
## what
* Only deploy on tagged releases to `master` branch

## why
* We want to release new version only after explicitly tagging it for new release
* More control
* Stability
