### PR TITLE
Use hugo related content

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -106,3 +106,33 @@ name = "<i class='fa fa-envelope'></i> <label>Contact Us</label>"
 url = "/documentation/contact-us/"
 identifier = "nav-contact-us"
 weight = 70
+
+
+[related]
+
+# Only include matches with rank >= threshold. This is a normalized rank between 0 and 100.
+threshold = 60
+
+# To get stable "See also" sections we, by default, exclude newer related pages. (set to false)
+includeNewer = true
+
+# Will lower case keywords in both queries and in the indexes.
+toLower = true
+
+[[related.indices]]
+name = "keywords"
+weight = 150
+
+[[related.indices]]
+name  = "author"
+toLower = true
+weight = 30
+
+[[related.indices]]
+name  = "tags"
+weight = 100
+
+[[related.indices]]
+name  = "date"
+weight = 10
+pattern = "2006"

--- a/layouts/partials/flex/body-aftercontent.html
+++ b/layouts/partials/flex/body-aftercontent.html
@@ -1,5 +1,5 @@
   {{if not .IsHome}}
-    <div class="addthis_relatedposts_inline"></div>
+    {{ partial "related.html" . }}
   {{end}}
 
   {{if not .IsHome}}
@@ -29,19 +29,6 @@
 
 
     <div class="copyright"> © {{ now.Format "2006"}} Cloud Posse, LLC. <a rel="license" href="/license/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a></div>
-
-    <div class="custom">
-{{ $footer := print "_footer." .Lang }}
-{{ range where .Site.Pages "Source.BaseFileName" $footer }}
-  {{ .Content }}
-{{else}}
-  {{ if .Site.GetPage "page" "_footer.md" }}
-    {{(.Site.GetPage "page" "_footer.md").Content}}
-  {{else}}
-    {{ T "create-footer-md" }}
-  {{end}}
-{{end}}
-    </div>
 
     {{with .Params.LastModifierDisplayName}}
     <div class="author">

--- a/layouts/partials/related.html
+++ b/layouts/partials/related.html
@@ -1,0 +1,11 @@
+{{ $related := .Site.RegularPages.Related . | first 5 }}
+{{ with $related }}
+<div id="related">
+  <h4>See Also</h4>
+  <ul>
+      {{ range . }}
+      <li><i class="fa fa-chevron-right"></i><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+      {{ end }}
+  </ul>
+</div>
+{{ end }}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -347,7 +347,7 @@ aside#right-sidebar nav > ul {
 }
 
 aside#right-sidebar nav > ul ul {
-  list-style: none;
+  list-style: none; 
   margin-left: 15px;
 }
 
@@ -811,26 +811,21 @@ div.landing-description {
   display: none;
 }
 
-.addthis_relatedposts_inline {
-    width: 717px;
+
+
+#related h4 {
+  color: #555;
+  font-size: 23px;
+  font-weight: bold;
 }
 
-.addthis_relatedposts_inline .at4-recommended .at4-recommended-item {
-  border: 0px;
+#related ul {
+  list-style-type: none;
+  line-height: 1.6em;
 }
 
-.addthis-smartlayers .at4-recommended.at-inline .at-h3.at-recommended-label {
-    color: #555;
-    font-size: 23px;
-    font-weight: 600;
-}
-
-.addthis-smartlayers .at4-recommended.at-medium .at4-recommended-item {
-  width: 200px;
-}
-
-.addthis-smartlayers .at4-recommended.at-medium .at4-recommended-item .at4-recommended-item-caption .at-h4 {
-  font-size: 1em;
+#related i {
+  margin-right: 10px;
 }
 
 div.calendly-badge-widget {
@@ -950,6 +945,7 @@ body > footer .footline .tags {
 body > footer .footline .tags, body > footer .footline .copyright {
   display: inline-block;
   float: left;
+  line-height: 2.2em;
 }
 
 footer .footline .date {


### PR DESCRIPTION
## what
* Switch to hugo related content from [add this](https://addthis.com)

## why
* Add this gives us no control over reindexing urls
* After migration to hugo, AddThis links to mostly 404 pages since link structure changed
* Hugo lets us customize ranking algorithm based on logical relationships between content vs AddThis which simply associates content based on click behavior
