### PR TITLE
Add include-code-block shortcode

### DIFF
--- a/content/development/github/best-practices.md
+++ b/content/development/github/best-practices.md
@@ -1,0 +1,7 @@
+# Use `.gitignore`
+
+Use a `.gitignore` file in the root of every repo to exclude files that should never be committed. 
+
+Here's an example of the [`.gitignore`](https://github.com/cloudposse/docs/blob/master/.gitignore) from our documentation repository. 
+
+{{% include-code-block file=".gitignore" title="Example .gitignore" lang="hcl" %}}

--- a/layouts/shortcodes/include-code-block.html
+++ b/layouts/shortcodes/include-code-block.html
@@ -1,0 +1,4 @@
+<div class="dialog {{ .Get "type" | default "code-block" }}">
+  <h4><i class="{{ .Get "icon" | default "fa fa-code" }}" aria-hidden="true"></i>{{ .Get "title" | default "Example" }}</h4>
+  <p>{{ (printf "```%s\n%s\n```" (.Get "lang" | default "text") (readFile (.Get "file"))) | markdownify}}</p>
+</div>


### PR DESCRIPTION
## what
* Define new `include-code-block` short code
* Add usage example

## why
* Keep code out of documentation to make documents more readable 
* Open up the possibility of linting code examples