### PR TITLE
Increase cache validity

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -27,6 +27,7 @@ EnforceHTTPS: false
 
 HTTPHeaders: 
   User-Agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Safari/537.36"
+  Referer: "https://docs.cloudposse.com/"
 
 # Turns off image alt attribute checking.
 IgnoreAltMissing: true

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -47,6 +47,8 @@ IgnoreURLs:
 - "img.shields.io"
 # Rate limiting precludes us from testing GitHub links
 - "github.com"
+# Site started blocking us
+- "blog.gopheracademy.com"
 
 # Array of regexs of directories to ignore when scanning for HTML files.
 IgnoreDirs:

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -53,7 +53,8 @@ IgnoreDirs:
 - "revealjs"
 
 # Cache validity period, accepts go.time duration strings (…"m", "h").
-CacheExpires: "48h"
+# Two-weeks = 336 Hours
+CacheExpires: "336h"
 
 # Maximum number of open HTTP connections (keep this low to avoid GitHub rate limits)
 HTTPConcurrencyLimit: 2


### PR DESCRIPTION
## what
* Increase cache validity from 2 days to 2 weeks
* Add `Referer` [sic] header
* Do not test links to `blog.gopheracademy.com` (blocked)

## why
* Avoid getting blocked by remote sites due to rate limiting