### PR TITLE
Revert partialCached

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -3,30 +3,30 @@
   <head>
     <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
     {{if .Site.Params.themeStyle}}
-      {{ partialCached (printf "%s/head.html" .Site.Params.themeStyle) . }}
+      {{ partial (printf "%s/head.html" .Site.Params.themeStyle) . }}
     {{else}}
-      {{ partialCached "flex/head.html" . }}
+      {{ partial "flex/head.html" . }}
     {{end}}
   </head>
   <body data-url="{{ .RelPermalink }}" class="cloudposse page-404">
     {{if .Site.Params.themeStyle}}
-      {{ partialCached (printf "%s/body-beforecontent.html" .Site.Params.themeStyle) . }}
+      {{ partial (printf "%s/body-beforecontent.html" .Site.Params.themeStyle) . }}
     {{else}}
-      {{ partialCached "flex/body-beforecontent.html" . }}
+      {{ partial "flex/body-beforecontent.html" . }}
     {{end}}
     
 	<p><img src="{{"/assets/404-not-found.png" | relURL}}" style="width:50%"></img></p>    
     
     {{if .Site.Params.themeStyle}}
-      {{ partialCached (printf "%s/body-aftercontent.html" .Site.Params.themeStyle) . }}
+      {{ partial (printf "%s/body-aftercontent.html" .Site.Params.themeStyle) . }}
     {{else}}
-      {{ partialCached "flex/body-aftercontent.html" . }}
+      {{ partial "flex/body-aftercontent.html" . }}
     {{ end }}
 
     {{ block "footer" . }}
     {{ end }}
 
-    {{ partialCached "custom-footer.html" . }}
+    {{ partial "custom-footer.html" . }}
   </body>
 </html>
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,9 +2,9 @@
 <html>
   <head>
     {{if .Site.Params.themeStyle}}
-      {{ partialCached (printf "%s/head.html" .Site.Params.themeStyle) . }}
+      {{ partial (printf "%s/head.html" .Site.Params.themeStyle) . }}
     {{else}}
-      {{ partialCached "flex/head.html" . }}
+      {{ partial "flex/head.html" . }}
     {{end}}
   </head>
 
@@ -16,23 +16,23 @@
   <body data-url="{{ .RelPermalink }}" class="cloudposse no-page-slug">
   {{ end }}
     {{if .Site.Params.themeStyle}}
-      {{ partialCached (printf "%s/body-beforecontent.html" .Site.Params.themeStyle) . }}
+      {{ partial (printf "%s/body-beforecontent.html" .Site.Params.themeStyle) . }}
     {{else}}
-      {{ partialCached "flex/body-beforecontent.html" . }}
+      {{ partial "flex/body-beforecontent.html" . }}
     {{end}}
     
     {{ block "main" . }}
     {{ end }}
     
     {{if .Site.Params.themeStyle}}
-      {{ partialCached (printf "%s/body-aftercontent.html" .Site.Params.themeStyle) . }}
+      {{ partial (printf "%s/body-aftercontent.html" .Site.Params.themeStyle) . }}
     {{else}}
-      {{ partialCached "flex/body-aftercontent.html" . }}
+      {{ partial "flex/body-aftercontent.html" . }}
     {{ end }}
 
     {{ block "footer" . }}
     {{ end }}
 
-    {{ partialCached "custom-footer.html" . }}
+    {{ partial "custom-footer.html" . }}
   </body>
 </html>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -5,7 +5,7 @@
 {{ $paginator := .Paginator }}
 
 <div class="extra-pagination inner">
-{{ partialCached "pagination.html" $paginator }}
+{{ partial "pagination.html" $paginator }}
 </div>
 
 {{ range $index, $page := $paginator.Pages }}
@@ -14,7 +14,7 @@
 
 <div style="margin-bottom:2rem"></div>
 
-{{ partialCached "pagination.html" $paginator }}
+{{ partial "pagination.html" $paginator }}
 
 {{end}}
 {{end}}

--- a/layouts/partials/debug.html
+++ b/layouts/partials/debug.html
@@ -2,11 +2,11 @@
 <!-- https://github.com/kaushalmodi/ox-hugo/blob/master/test/site/themes/bare_min/layouts/partials/debug.html -->
 
 <!-- Usage examples:
-     {{/* partialCached "debug.html" .Params */}}
-     {{/* partialCached "debug.html" .Site */}}
-     {{/* partialCached "debug.html" .GitInfo */}}
-     {{/* partialCached "debug.html" .Resources */}}
-     {{/* partialCached "debug.html" .File */}}
+     {{/* partial "debug.html" .Params */}}
+     {{/* partial "debug.html" .Site */}}
+     {{/* partial "debug.html" .GitInfo */}}
+     {{/* partial "debug.html" .Resources */}}
+     {{/* partial "debug.html" .File */}}
   -->
 {{ $value              := . }}
 {{ $type               := (printf "%T" $value) }}
@@ -36,7 +36,7 @@
 {{ printf "%s" $value | safeHTML }}
 {{ else if $typeIsSlice }}
 {{ range $value }}
-{{ partialCached "debug.html" . }} <!-- Recursive call FTW! -->
+{{ partial "debug.html" . }} <!-- Recursive call FTW! -->
 {{ end }}
 {{ else if $typeIsMap }}
 {{ if (gt (len $value) 0) }}
@@ -49,12 +49,12 @@
   <!-- Print the date only if it is not at its initial value of Jan 1, 0001 -->
   {{ if (ne "0001-01-01" ($value1.Format "2006-01-02")) }}
   {{ printf "<tr><td class=\"key\">%s</td><td class=\"type\">%s</td><td class=\"value\">" $key1 $type1 | safeHTML }}
-      {{ partialCached "debug.html" $value1 }} <!-- Recursive call FTW! -->
+      {{ partial "debug.html" $value1 }} <!-- Recursive call FTW! -->
       {{ printf "</td></tr>" | safeHTML }}
   {{ end }}
   {{ else }}
   {{ printf "<tr><td class=\"key\">%s</td><td class=\"type\">%s</td><td class=\"value\">" $key1 $type1 | safeHTML }}
-      {{ partialCached "debug.html" $value1 }} <!-- Recursive call FTW! -->
+      {{ partial "debug.html" $value1 }} <!-- Recursive call FTW! -->
       {{ printf "</td></tr>" | safeHTML }}
   {{ end }}
   {{ end }}
@@ -69,7 +69,7 @@
     <tr><th class="key">SiteInfo Variable</th><th class="value">Value</th></tr>
     {{ range $idx, $elem := $siteVarNames }}
     {{ printf "<tr><td class=\"key\">%s</td><td class=\"value\">" $elem | safeHTML }}
-        {{ partialCached "debug.html" (index $siteVarSymbols $idx) }} <!-- Recursive call FTW! -->
+        {{ partial "debug.html" (index $siteVarSymbols $idx) }} <!-- Recursive call FTW! -->
         {{ printf "</td></tr>" | safeHTML }}
     {{ end }}
   </table>
@@ -80,7 +80,7 @@
     <tr><th class="key">GitInfo Variable</th><th class="value">Value</th></tr>
     {{ range $idx, $elem := $gitInfoVarNames }}
     {{ printf "<tr><td class=\"key\">%s</td><td class=\"value\">" $elem | safeHTML }}
-        {{ partialCached "debug.html" (index $gitInfoVarSymbols $idx) }} <!-- Recursive call FTW! -->
+        {{ partial "debug.html" (index $gitInfoVarSymbols $idx) }} <!-- Recursive call FTW! -->
         {{ printf "</td></tr>" | safeHTML }}
     {{ end }}
   </table>
@@ -91,7 +91,7 @@
     <tr><th class="key">OutputFormat Variable</th><th class="value">Value</th></tr>
     {{ range $idx, $elem := $OutputFormatVarNames }}
     {{ printf "<tr><td class=\"key\">%s</td><td class=\"value\">" $elem | safeHTML }}
-        {{ partialCached "debug.html" (index $OutputFormatVarSymbols $idx) }} <!-- Recursive call FTW! -->
+        {{ partial "debug.html" (index $OutputFormatVarSymbols $idx) }} <!-- Recursive call FTW! -->
         {{ printf "</td></tr>" | safeHTML }}
     {{ end }}
   </table>
@@ -102,7 +102,7 @@
     <tr><th class="key">Resource Variable</th><th class="value">Value</th></tr>
     {{ range $idx, $elem := $ResourceVarNames }}
     {{ printf "<tr><td class=\"key\">%s</td><td class=\"value\">" $elem | safeHTML }}
-        {{ partialCached "debug.html" (index $ResourceVarSymbols $idx) }} <!-- Recursive call FTW! -->
+        {{ partial "debug.html" (index $ResourceVarSymbols $idx) }} <!-- Recursive call FTW! -->
         {{ printf "</td></tr>" | safeHTML }}
     {{ end }}
   </table>
@@ -114,7 +114,7 @@
     <tr><th class="key">Page Variable</th><th class="value">Value</th></tr>
     {{ range $idx, $elem := $PageVarNames }}
     {{ printf "<tr><td class=\"key\">%s</td><td class=\"value\">" $elem | safeHTML }}
-        {{ partialCached "debug.html" (index $PageVarSymbols $idx) }} <!-- Recursive call FTW! -->
+        {{ partial "debug.html" (index $PageVarSymbols $idx) }} <!-- Recursive call FTW! -->
         {{ printf "</td></tr>" | safeHTML }}
     {{ end }}
   </table>
@@ -126,7 +126,7 @@
     <tr><th class="key">FileInfo Variable</th><th class="value">Value</th></tr>
     {{ range $idx, $elem := $FileInfoVarNames }}
     {{ printf "<tr><td class=\"key\">%s</td><td class=\"value\">" $elem | safeHTML }}
-        {{ partialCached "debug.html" (index $FileInfoVarSymbols $idx) }} <!-- Recursive call FTW! -->
+        {{ partial "debug.html" (index $FileInfoVarSymbols $idx) }} <!-- Recursive call FTW! -->
         {{ printf "</td></tr>" | safeHTML }}
     {{ end }}
   </table>

--- a/layouts/partials/flex/body-aftercontent.html
+++ b/layouts/partials/flex/body-aftercontent.html
@@ -1,10 +1,10 @@
   {{if not .IsHome}}
-    {{ partialCached "related.html" . }}
+    {{ partial "related.html" . }}
   {{end}}
 
   {{if not .IsHome}}
   <div class="chevrons">
-    {{ partialCached "next-prev-page.html" . }}
+    {{ partial "next-prev-page.html" . }}
   </div>
 
   </section>
@@ -44,4 +44,4 @@
    </div>
 </footer>
 
-{{ partialCached "flex/scripts.html" . }}
+{{ partial "flex/scripts.html" . }}

--- a/layouts/partials/flex/body-beforecontent.html
+++ b/layouts/partials/flex/body-beforecontent.html
@@ -47,7 +47,7 @@
     <div class="nav-select">
       <center>
         <select onchange="javascript:location.href = this.value;">
-          {{partialCached "flex/selectnavigation.html" .}}
+          {{partial "flex/selectnavigation.html" .}}
         </select><i class="fa fa-angle-down"></i>
       </center>
     </div>
@@ -69,7 +69,7 @@
 <article>
   {{if .IsHome}}
     <div class="homepage">
-      {{ partialCached "homepage.html" . }}
+      {{ partial "homepage.html" . }}
     </div>
   {{else}}
   <aside id="left-sidebar">
@@ -82,11 +82,11 @@
         </li>
       {{- end}}
 
-      {{- partialCached "menu.html" . }}
+      {{- partial "menu.html" . }}
     </ul>
-    {{- partialCached "language-selector.html" . }}
+    {{- partial "language-selector.html" . }}
     <section>
-      {{- partialCached "menu-footer.html" . }}
+      {{- partial "menu-footer.html" . }}
     </section>
   </aside>
 

--- a/layouts/partials/flex/head.html
+++ b/layouts/partials/flex/head.html
@@ -15,4 +15,4 @@
 <script type="text/javascript">
       var baseurl = "{{.Site.BaseURL}}";
 </script>
-{{ partialCached "custom-head.html" . }}
+{{ partial "custom-head.html" . }}


### PR DESCRIPTION
## what
* Revert `partialCached`

## why
* Incorrectly implemented without variants
* All page headers and breadcrumbs were the same on all pages (and probably other things as well)

## references
- <https://gohugo.io/functions/partialcached/>
