### PR TITLE
re-enable github link validation

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -47,7 +47,7 @@ IgnoreURLs:
 # Rate limiting precludes us from testing badge shields
 - "img.shields.io"
 # Rate limiting precludes us from testing GitHub links
-- "github.com"
+- "github.com/cloudposse/docs/blob"
 # Site started blocking us
 - "blog.gopheracademy.com"
 


### PR DESCRIPTION
## what
* Re-enable github link validation (excluding `cloudposse/docs/blob` urls which are too plentiful)

## why
* We fixed caching on Codefresh, so I think we can avoid getting rate limited for the time being