### PR TITLE
Makefile - Fix Algolia env 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ export HTMLTEST_CONFIG ?= .htmltest.yml
 export ALGOLIA_INDEX_FILE ?= $(HUGO_PUBLISH_DIR)/index.algolia.json
 export ALGOLIA_INDEX_NAME ?= dev
 export ALGOLIA_APP_ID ?= docs
-export ALGOLIA_ADMIN_KEY =?
+export ALGOLIA_ADMIN_KEY ?=
 
 export ASCIINEMA_VERSION ?= 2.6.1
 


### PR DESCRIPTION
## what
* Use proper `make` syntax

## why
* We were accidentally overriding the `ALGOLIA_API_KEY` with the value of `?`