### PR TITLE
Promote slack team

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 .git/
 node_modules/
+public/
+test/

--- a/content/documentation/contact-us.md
+++ b/content/documentation/contact-us.md
@@ -10,17 +10,17 @@ We help companies achieve success in the cloud by automating systems for maximum
 
 # Hire us!
 
-|                |                                                                                 |
-|:-------------- |:------------------------------------------------------------------------------- |
-| Email          | [hello@cloudposse.com](mailto:hello@cloudposse.com)                             |
-| Website        | <https://cloudposse.com>                                                        |
-| GitHub         | <https://github.com/cloudposse>                                                 |
-| Office Address | 45 S. Arroyo Parkway, Pasadena, CA 91105                                        |
-| Schedule Time  | [calendly.com/cloudposse](https://calendly.com/cloudposse)                      |
-| Call Us        | [+1 (310) 496-6556](tel:+13104966556)                                           |
-| Slack          | [`#community`](https://cloudposse.com/slack/)                                   |
-| Twitter        | [twitter.com/cloudposse](https://twitter.com/cloudposse)                        |
-| LinkedIn       | [linkedin.com/company/cloudposse](https://www.linkedin.com/company/cloudposse/) |
+|                |                                                                                            |
+|:-------------- |:------------------------------------------------------------------------------------------ |
+| Email          | [hello@cloudposse.com](mailto:hello@cloudposse.com)                                        |
+| Website        | <https://cloudposse.com>                                                                   |
+| GitHub         | <https://github.com/cloudposse>                                                            |
+| Office Address | 45 S. Arroyo Parkway, Pasadena, CA 91105                                                   |
+| Schedule Time  | [calendly.com/cloudposse](https://calendly.com/cloudposse)                                 |
+| Call Us        | [+1 (310) 496-6556](tel:+13104966556)                                                      |
+| Slack          | [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com) | 
+| Twitter        | [twitter.com/cloudposse](https://twitter.com/cloudposse)                                   |
+| LinkedIn       | [linkedin.com/company/cloudposse](https://www.linkedin.com/company/cloudposse/)            |
 
 # Partnership Opportunities
 

--- a/layouts/partials/flex/body-beforecontent.html
+++ b/layouts/partials/flex/body-beforecontent.html
@@ -38,13 +38,14 @@
   <div class="container">
     {{if not .IsHome}}
     <div class="breadcrumbs" itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb">
-      {{ template "breadcrumb" dict "page" . "value" .Title }}   
+      {{ template "breadcrumb" dict "page" . "value" .Title }}
     </div>
     <div class="searchbox">
       <div class="fa fa-search"></div>
       <input type="text" placeholder="Search" class="search-box">
     </div>
     {{end}}
+    <script async defer src="https://slack.cloudposse.com/slackin.js"></script>
     <div class="nav-select">
       <center>
         <select onchange="javascript:location.href = this.value;">
@@ -128,7 +129,7 @@
 {{define "breadcrumb"}}
 {{ if .page.Parent}}
 {{$value := (printf "<a href='%s'>%s</a> <i class='fa fa-chevron-right'></i> %s" .page.Parent.URL .page.Parent.Title .value)}}
-{{ template "breadcrumb" dict "page" .page.Parent "value" $value }} 
+{{ template "breadcrumb" dict "page" .page.Parent "value" $value }}
 {{else}}
  {{.value|safeHTML}}
 {{end}}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,1 +1,5 @@
-/* Custom css for quickfixes without compiling should be added here. */
+/* Custom CSS for quickfixes without compiling should be added here. */
+
+.subnav .__slackin {
+  float: right;
+}


### PR DESCRIPTION
## what
* Add announcement for slack team
* Add button to subnav
* Update links to point to `slack.cloudposse.com`

## why
* Foster community development

## demo

![image](https://user-images.githubusercontent.com/52489/42552822-11425294-8493-11e8-99fb-98f309ac9087.png)

