### PR TITLE
[tools/aws-vault] Add `-L` option to `curl`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:10.8-stretch
+FROM node:10.9-stretch
 
-ARG APT_PACKAGES="python3 python3-pip locales jq" 
+ARG APT_PACKAGES="python3 python3-pip locales jq"
 RUN apt-get update && \
     apt-get install -y ${APT_PACKAGES} && \
     rm -rf /var/lib/apt/lists/*

--- a/content/faq/kiam-error-detecting-arn-prefix.md
+++ b/content/faq/kiam-error-detecting-arn-prefix.md
@@ -31,6 +31,6 @@ The `kiam-server` also has problems:
 
 Here are a few common causes of this problem:
 
-  1. The TLS certs don't match the hostname of the `kiam-server`. If [using our script](https://github.com/cloudposse/geodesic/tree/master/rootfs/conf/kops/kiam) and helmfile, this should be mitigated.
+  1. The TLS certs don't match the hostname of the `kiam-server`. If [using our script](https://github.com/cloudposse/helmfiles/tree/master/scripts/kiam) and helmfile, this should be mitigated.
   2. When upgrading from `kube2iam` to `kiam`, some `iptables` rules are orphaned that cause problems. Reboot all servers to flush orphaned `iptables` rules.
   3. Make sure any previous `kube2iam` helm release has been deleted

--- a/content/faq/kube2iam-assuming-role-access-denied.md
+++ b/content/faq/kube2iam-assuming-role-access-denied.md
@@ -19,8 +19,8 @@ time="2018-06-19T19:58:43Z" level=error msg="Error assuming role AccessDenied: U
 
 # Answer
 
-We've seen this error with `kube2iam` many times due to AWS API rate limiting. It affects even small kubernetes clusters running `kube2iam`. For AWS, the request rate limit is account-wide and other applications deployed in the same account may be depleting the budget independently. There are fundamental [problems with the architecutre of `kube2iam`](https://medium.com/@pingles/kiam-iterating-for-security-and-reliability-5e793ab93ec3) that are addressed in [`kiam`](https://github.com/uswitch/kiam).
+We've seen this error with `kube2iam` many times due to AWS API rate limiting. It affects even small Kubernetes clusters running `kube2iam`. For AWS, the request rate limit is account-wide and other applications deployed in the same account may be depleting the budget independently. There are fundamental [problems with the architecutre of `kube2iam`](https://medium.com/@pingles/kiam-iterating-for-security-and-reliability-5e793ab93ec3) that are addressed in [`kiam`](https://github.com/uswitch/kiam).
 
 The only "quick fix" we've seen is to `kubectl drain` drain afflicted node and then terminate it so a new one is spawned in its place. You may need to perform this action repeatedly on all nodes. New nodes will have their rate limits reset to zero, however, this is only a temporary fix and the problem will resurface as soon as limits are exceeded.
 
-The long-term fix is to switch to `kiam`. Geodesic ships with support for `kiam` in our [`helmfile`](https://github.com/cloudposse/geodesic/tree/master/rootfs/conf/kops) distribution.
+The long-term fix is to switch to `kiam`. Our comprehensive distribution of [`helmfiles`](https://github.com/cloudposse/helmfiles) ships with support for [`kiam`](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0010.kiam.yaml).

--- a/content/kubernetes-backing-services/external-dns/external-dns.md
+++ b/content/kubernetes-backing-services/external-dns/external-dns.md
@@ -62,15 +62,15 @@ You can install `external-dns` in a few different ways, but we recommend using t
 
 1. Set with chamber the `EXTERNAL_DNS_IAM_ROLE` secret to IAM role name from previous step.
 2. Set with chamber the `EXTERNAL_DNS_TXT_OWNER_ID` secret to cluster name.
-3. Set with chamber the `EXTERNAL_DNS_TXT_PREFIX` secret to random string.
-4. Run then install `external-dns` using `helmfile sync`.
+3. Set with chamber the `EXTERNAL_DNS_TXT_PREFIX` secret to a random string.
+4. Install `external-dns` using `helmfile sync`.
 
 {{% dialog type="code-block" icon="fa fa-code" title="Install external-dns" %}}
 ```
 chamber write kops EXTERNAL_DNS_IAM_ROLE example-staging-external-dns
 chamber write kops EXTERNAL_DNS_TXT_OWNER_ID us-west-2.staging.example.com
 chamber write kops EXTERNAL_DNS_TXT_PREFIX "$(uuidgen)-"
-chamber exec kops -- helmfile -f 0100.external-dns.yaml sync
+chamber exec kops -- helmfile --selector chart=external-dns sync
 ```
 {{% /dialog %}}
 

--- a/content/kubernetes-backing-services/external-dns/external-dns.md
+++ b/content/kubernetes-backing-services/external-dns/external-dns.md
@@ -56,7 +56,7 @@ In the example the iam role name is `kops_external_dns_role_name = example-stagi
 
 ## Install Chart
 
-You can install `external-dns` in a few different ways, but we recomend to use the [Master Helmfile](https://github.com/cloudposse/geodesic/blob/master/rootfs/conf/kops/helmfile.yaml).
+You can install `external-dns` in a few different ways, but we recommend using the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0100.external-dns.yaml).
 
 ## Install with Master Helmfile
 
@@ -70,7 +70,7 @@ You can install `external-dns` in a few different ways, but we recomend to use t
 chamber write kops EXTERNAL_DNS_IAM_ROLE example-staging-external-dns
 chamber write kops EXTERNAL_DNS_TXT_OWNER_ID us-west-2.staging.example.com
 chamber write kops EXTERNAL_DNS_TXT_PREFIX "$(uuidgen)-"
-chamber exec kops -- helmfile -f /conf/kops/helmfile.yaml --selector namespace=kube-system,chart=external-dns sync
+chamber exec kops -- helmfile -f 0100.external-dns.yaml sync
 ```
 {{% /dialog %}}
 
@@ -78,9 +78,9 @@ Replace with values to suit your specific project.
 
 ## Install with Custom Helmfile
 
-Add to your [Kubernetes Backing Services](/kubernetes-backing-services) Helmfile this code
+Add this code to your [Kubernetes Backing Services](/kubernetes-backing-services) Helmfile:
 
-{{% include-code-block  title="helmfile.yaml" file="kubernetes-backing-services/external-dns/examples/external-dns-helmfile.yaml" language="yaml" %}}
+{{% include-code-block  title="helmfile" file="kubernetes-backing-services/external-dns/examples/external-dns-helmfile.yaml" language="yaml" %}}
 
 Then follow the instructions for running [`helmfile sync`]({{< relref "tools/helmfile.md" >}}).
 
@@ -97,7 +97,7 @@ Here are some examples:
 
 {{% include-code-block title="values.yaml" file="kubernetes-backing-services/external-dns/examples/external-dns-usage-values.yaml" language="yaml" %}}
 
-{{% include-code-block title="helmfile.yaml" file="kubernetes-backing-services/external-dns/examples/external-dns-usage-helmfile.yaml" language="yaml" %}}
+{{% include-code-block title="helmfile" file="kubernetes-backing-services/external-dns/examples/external-dns-usage-helmfile.yaml" language="yaml" %}}
 
 {{% dialog type="info" icon="fa-info-circle" title="Note" %}}
 There is no unified specification on how to structure helm chart values. Different charts may have very different structures of the value parameters. The only way to know for sure what is supported is to refer to the chart manifests.

--- a/content/kubernetes-backing-services/iam/kube2iam.md
+++ b/content/kubernetes-backing-services/iam/kube2iam.md
@@ -49,9 +49,9 @@ Now to leverage IAM Roles with your `kops` cluster, you'll need to install `kube
 
 ### Install with Helmfile
 
-{{% dialog type="code-block" icon="fa fa-code" title="Install `kube-lego`" %}}
+{{% dialog type="code-block" icon="fa fa-code" title="Install `kube2iam`" %}}
 ```
-helmfile -f 0110.kube-lego.yaml sync
+helmfile --selector chart=kube2iam sync
 ```
 {{% /dialog %}}
 

--- a/content/kubernetes-backing-services/iam/kube2iam.md
+++ b/content/kubernetes-backing-services/iam/kube2iam.md
@@ -45,13 +45,13 @@ Follow the instructions to [apply changes to the kops cluster]({{< relref "geode
 
 ## Kops Integration
 
-Now to leverage IAM Roles with your `kops` cluster, you'll need to install `kube2iam`. There are a number of ways to go about this, but we recommend to use our Master Helmfile that ships with Geodesic.
+Now to leverage IAM Roles with your `kops` cluster, you'll need to install `kube2iam`. There are a number of ways to go about this, but we recommend to use our [Helmfiles](https://github.com/cloudposse/helmfiles).
 
-### Install with Master Helmfile
+### Install with Helmfile
 
 {{% dialog type="code-block" icon="fa fa-code" title="Install `kube-lego`" %}}
 ```
-helmfile -f /conf/kops/helmfile.yaml --selector chart=kube2iam sync
+helmfile -f 0110.kube-lego.yaml sync
 ```
 {{% /dialog %}}
 
@@ -81,7 +81,7 @@ Here are some examples:
 
 {{% include-code-block title="values.yaml" file="kubernetes-backing-services/iam/examples/kube2iam-usage-values.yaml" language="yaml" %}}
 
-{{% include-code-block title="helmfile.yaml" file="kubernetes-backing-services/iam/examples/kube2iam-usage-helmfile.yaml" language="yaml" %}}
+{{% include-code-block title="helmfile" file="kubernetes-backing-services/iam/examples/kube2iam-usage-helmfile.yaml" language="yaml" %}}
 
 {{% dialog type="info" icon="fa-info-circle" title="Note" %}}
 There is no unified specification for the structure of helm chart values. Different charts may have very different structures to values. The only way to know for sure what is supported is to refer to the chart manifests. Additionally, there's no schema validation for `values.yaml`, so specifying an incorrect structure will not raise any alarms.

--- a/content/kubernetes-backing-services/ingress/nginx-ingress-controller.md
+++ b/content/kubernetes-backing-services/ingress/nginx-ingress-controller.md
@@ -23,7 +23,7 @@ Follow these instructions:
 {{% dialog type="code-block" icon="fa fa-code" title="Install Ingress" %}}
 ```
 chamber write kops NGINX_INGRESS_HOSTNAME ingress.us-west-2.staging.example.com
-chamber exec kops -- helmfile --selector chart=nginx-ingress sync
+chamber exec kops -- helmfile --selector chart=nginx-ingress,repo=stable sync
 ```
 {{% /dialog %}}
 

--- a/content/kubernetes-backing-services/ingress/nginx-ingress-controller.md
+++ b/content/kubernetes-backing-services/ingress/nginx-ingress-controller.md
@@ -23,7 +23,7 @@ Follow these instructions:
 {{% dialog type="code-block" icon="fa fa-code" title="Install Ingress" %}}
 ```
 chamber write kops NGINX_INGRESS_HOSTNAME ingress.us-west-2.staging.example.com
-chamber exec kops -- helmfile -f 0320.nginx-ingress.yaml sync
+chamber exec kops -- helmfile --selector chart=nginx-ingress sync
 ```
 {{% /dialog %}}
 

--- a/content/kubernetes-backing-services/ingress/nginx-ingress-controller.md
+++ b/content/kubernetes-backing-services/ingress/nginx-ingress-controller.md
@@ -11,7 +11,7 @@ None
 
 # Install
 
-You can install the `nginx-ingress` controller in few different ways, but we recommend to use the [Master Helmfile](https://github.com/cloudposse/geodesic/blob/master/rootfs/conf/kops/helmfile.yaml).
+You can install the `nginx-ingress` controller in few different ways, but we recommend to use the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0320.nginx-ingress.yaml).
 
 ## Install using Master Helmfile
 
@@ -23,7 +23,7 @@ Follow these instructions:
 {{% dialog type="code-block" icon="fa fa-code" title="Install Ingress" %}}
 ```
 chamber write kops NGINX_INGRESS_HOSTNAME ingress.us-west-2.staging.example.com
-chamber exec kops -- helmfile -f /conf/kops/helmfile.yaml --selector namespace=kube-system,chart=nginx-ingress sync
+chamber exec kops -- helmfile -f 0320.nginx-ingress.yaml sync
 ```
 {{% /dialog %}}
 
@@ -40,7 +40,7 @@ Environment variables can be specified in Geodesic Module `Dockerfile` or in [Ch
 
 Add to your [Kubernetes Backing Services](/kubernetes-backing-services) Helmfile this code
 
-{{% include-code-block  title="helmfile.yaml" file="kubernetes-backing-services/ingress/examples/nginx-ingress-helmfile.yaml" language="yaml" %}}
+{{% include-code-block  title="helmfile" file="kubernetes-backing-services/ingress/examples/nginx-ingress-helmfile.yaml" language="yaml" %}}
 
 Then do [Helmfile]({{< relref "tools/helmfile.md" >}}) sync follow instructions
 
@@ -54,7 +54,7 @@ Here are some examples:
 
 {{% include-code-block title="values.yaml" file="kubernetes-backing-services/ingress/examples/nginx-ingress-usage-helm-values.yaml" language="yaml" %}}
 
-{{% include-code-block title="helmfile.yaml" file="kubernetes-backing-services/ingress/examples/nginx-ingress-usage-helmfile.yaml" language="yaml" %}}
+{{% include-code-block title="helmfile" file="kubernetes-backing-services/ingress/examples/nginx-ingress-usage-helmfile.yaml" language="yaml" %}}
 
 {{% dialog type="info" icon="fa-info-circle" title="Note" %}}
 There is no unified specification for helm chart values structure. Different charts may have very different structures to values. The only way to know for sure what is supported is to refer to the chart manifests.

--- a/content/kubernetes-backing-services/monitoring/kube-prometheus.md
+++ b/content/kubernetes-backing-services/monitoring/kube-prometheus.md
@@ -110,7 +110,7 @@ grafana:
 ```
 * [Rebuild the Geodesic Module]({{< relref "geodesic/module/quickstart.md#build-install" >}})
 * [Run into the Geodesic Module shell]({{< relref "geodesic/module/quickstart.md#run-the-shell" >}})
-* Proceed to [install using the Master Helmfile]({{< relref "#install-using-master-helmfile" >}})
+* Proceed to [install using the Master Helmfile]({{< relref "#install-using-helmfile" >}})
 
 ### Installation using Custom Helmfile
 

--- a/content/kubernetes-backing-services/monitoring/kube-prometheus.md
+++ b/content/kubernetes-backing-services/monitoring/kube-prometheus.md
@@ -31,13 +31,13 @@ Kube Prometheus includes the following packages:
 
 You can install `kube-prometheus` in a few different ways, but we recommend to use the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0410.kube-prometheus.yaml).
 
-## Install using Master Helmfile
+## Install using Helmfile
 
 To install `kube-prometheus` run:
 
 {{% dialog type="code-block" icon="fa fa-code" title="Install kube-prometheus" %}}
 ```
-helmfile -f 0410.kube-prometheus.yaml sync
+helmfile --selector chart=kube-prometheus sync
 ```
 {{% /dialog %}}
 
@@ -65,7 +65,7 @@ Then follow the instructions for running [`helmfile sync`]({{< relref "tools/hel
 You can extend the default functionality of `kube-prometheus` to collect custom
 metrics and send alerts based on the metrics, and display the metric in Grafana charts.
 
-## Custom Netrics Collection
+## Custom Metrics Collection
 
 1. Check the [list of available exporters](https://prometheus.io/docs/instrumenting/exporters) to make sure there isn't already an Exporter that will meet your needs. For example, there are exporters that will work with [JMX](https://github.com/prometheus/jmx_exporter) out-of-the-box.
 2. If there is no exporter, then you'll need to [write your own](https://prometheus.io/docs/instrumenting/writing_exporters/) exporter that will provide required [metrics in correct format](https://prometheus.io/docs/instrumenting/exposition_formats/)

--- a/content/kubernetes-backing-services/monitoring/kube-prometheus.md
+++ b/content/kubernetes-backing-services/monitoring/kube-prometheus.md
@@ -29,7 +29,7 @@ Kube Prometheus includes the following packages:
 
 # Install
 
-You can install `kube-prometheus` in a few different ways, but we recomend to use the [Master Helmfile](https://github.com/cloudposse/geodesic/blob/master/rootfs/conf/kops/helmfile.yaml).
+You can install `kube-prometheus` in a few different ways, but we recommend to use the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0410.kube-prometheus.yaml).
 
 ## Install using Master Helmfile
 
@@ -37,7 +37,7 @@ To install `kube-prometheus` run:
 
 {{% dialog type="code-block" icon="fa fa-code" title="Install kube-prometheus" %}}
 ```
-helmfile -f /conf/kops/helmfile.yaml --selector namespace=monitoring,chart=kube-prometheus sync
+helmfile -f 0410.kube-prometheus.yaml sync
 ```
 {{% /dialog %}}
 
@@ -56,7 +56,7 @@ Environment variables can be specified in the Geodesic Module's `Dockerfile` or 
 
 Add to your [Kubernetes Backing Services](/kubernetes-backing-services) Helmfile this code
 
-{{% include-code-block  title="helmfile.yaml" file="kubernetes-backing-services/monitoring/examples/prometheus-operator-helmfile.yaml" language="yaml" %}}
+{{% include-code-block  title="helmfile" file="kubernetes-backing-services/monitoring/examples/prometheus-operator-helmfile.yaml" language="yaml" %}}
 
 Then follow the instructions for running [`helmfile sync`]({{< relref "tools/helmfile.md" >}}).
 

--- a/content/kubernetes-backing-services/monitoring/prometheus-operator.md
+++ b/content/kubernetes-backing-services/monitoring/prometheus-operator.md
@@ -12,7 +12,7 @@ None
 
 # Install
 
-You can install `prometheus-operator` in a few different ways, but we recomend to use the [Master Helmfile](https://github.com/cloudposse/geodesic/blob/master/rootfs/conf/kops/helmfile.yaml).
+You can install `prometheus-operator` in a few different ways, but we recommend to use the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0400.prometheus-operator.yaml).
 
 ## Install using Master Helmfile
 
@@ -20,7 +20,7 @@ To install `prometheus-operator` run
 
 {{% dialog type="code-block" icon="fa fa-code" title="Install prometheus-operator" %}}
 ```
-helmfile -f /conf/kops/helmfile.yaml --selector namespace=kube-system,chart=prometheus-operator sync
+helmfile -f helmfile.d/0400.prometheus-operator.yaml sync
 ```
 {{% /dialog %}}
 
@@ -35,9 +35,9 @@ Environment variables can be specified in the Geodesic Module's `Dockerfile` or 
 
 ## Install using Custom Helmfile
 
-Add to your [Kubernetes Backing Services](/kubernetes-backing-services) Helmfile this code
+Add this code to your [Kubernetes Backing Services](/kubernetes-backing-services) Helmfile:
 
-{{% include-code-block  title="helmfile.yaml" file="kubernetes-backing-services/monitoring/examples/prometheus-operator-helmfile.yaml" language="yaml" %}}
+{{% include-code-block  title="helmfile" file="kubernetes-backing-services/monitoring/examples/prometheus-operator-helmfile.yaml" language="yaml" %}}
 
 Then follow the instructions for running [`helmfile sync`]({{< relref "tools/helmfile.md" >}}).
 
@@ -47,7 +47,7 @@ Prometheus operator provides these new Kubernetes resources:
 
 * Prometheus
 * ServiceMonitor
-* Alertmanager
+* AlertManager
 
 These resources can be configured to interact with each other.
 

--- a/content/kubernetes-backing-services/monitoring/prometheus-operator.md
+++ b/content/kubernetes-backing-services/monitoring/prometheus-operator.md
@@ -4,7 +4,7 @@ description: ""
 ---
 [PrometheusOperator](https://github.com/coreos/prometheus-operator) provides
 [CRUD](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
-that simplifies creation/configuration/managment of [Prometheus]({{< relref "monitoring-and-alerting/prometheus.md" >}}) and [AlertManager]({{< relref "monitoring-and-alerting/alert-manager.md" >}}).
+that simplifies creation/configuration/management of [Prometheus]({{< relref "monitoring-and-alerting/prometheus.md" >}}) and [AlertManager]({{< relref "monitoring-and-alerting/alert-manager.md" >}}).
 
 # Dependencies
 
@@ -47,7 +47,7 @@ Prometheus operator provides these new Kubernetes resources:
 
 * Prometheus
 * ServiceMonitor
-* AlertManager
+* Alertmanager
 
 These resources can be configured to interact with each other.
 
@@ -60,10 +60,10 @@ that installs Prometheus, AlertManager and ServiceMonitors+Exporters to collect 
 
 [Read More](https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md#prometheus) about the Prometheus design.
 
-## AlertManager
+## Alertmanager
 
-[Read More](https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md#alertmanager) about the Alert Manager design.
+[Read More](https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md#alertmanager) about the Alertmanager design.
 
 ## ServiceMonitor
 
-[Read More](https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md#servicemonitor) about the Service Monitor design.
+[Read More](https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md#servicemonitor) about the ServiceMonitor design.

--- a/content/kubernetes-backing-services/monitoring/prometheus-operator.md
+++ b/content/kubernetes-backing-services/monitoring/prometheus-operator.md
@@ -14,13 +14,13 @@ None
 
 You can install `prometheus-operator` in a few different ways, but we recommend to use the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0400.prometheus-operator.yaml).
 
-## Install using Master Helmfile
+## Install using Helmfile
 
 To install `prometheus-operator` run
 
 {{% dialog type="code-block" icon="fa fa-code" title="Install prometheus-operator" %}}
 ```
-helmfile -f helmfile.d/0400.prometheus-operator.yaml sync
+helmfile --selector chart=prometheus-operator sync
 ```
 {{% /dialog %}}
 
@@ -53,14 +53,14 @@ These resources can be configured to interact with each other.
 
 {{% dialog type="tip" icon="fa fa-hand-o-right" title="Tip" %}}
 We recommend to install [kube-prometheus]({{< relref "kubernetes-backing-services/monitoring/kube-prometheus.md" >}})
-that installs Prometheus, Alert Manager and ServiceMonitors+Exporters to collect all required metrics from Kubernetes cluster.
+that installs Prometheus, AlertManager and ServiceMonitors+Exporters to collect all required metrics from Kubernetes cluster.
 {{% /dialog %}}
 
 ## Prometheus
 
 [Read More](https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md#prometheus) about the Prometheus design.
 
-## Alert Manager
+## AlertManager
 
 [Read More](https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md#alertmanager) about the Alert Manager design.
 

--- a/content/kubernetes-backing-services/tls-management/kube-lego-lets-encrypt.md
+++ b/content/kubernetes-backing-services/tls-management/kube-lego-lets-encrypt.md
@@ -23,7 +23,7 @@ You can install `kube-lego` in a few different ways, but we recommend to use the
 {{% dialog type="code-block" icon="fa fa-code" title="Install kube-lego" %}}
 ```
 chamber write kops KUBE_LEGO_EMAIL devops@example.com
-chamber exec kops -- helmfile -f 0110.kube-lego.yaml sync
+chamber exec kops --selector chart=kube-lego sync
 ```
 {{% /dialog %}}
 

--- a/content/kubernetes-backing-services/tls-management/kube-lego-lets-encrypt.md
+++ b/content/kubernetes-backing-services/tls-management/kube-lego-lets-encrypt.md
@@ -13,7 +13,7 @@ Out of the box, `kube-lego` support 2 types of [ingress controllers](https://git
 
 # Install
 
-You can install `kube-lego` in a few different ways, but we recomend to use the [Master Helmfile](https://github.com/cloudposse/geodesic/blob/master/rootfs/conf/kops/helmfile.yaml).
+You can install `kube-lego` in a few different ways, but we recommend to use the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0110.kube-lego.yaml).
 
 ## Install with Master Helmfile
 
@@ -23,7 +23,7 @@ You can install `kube-lego` in a few different ways, but we recomend to use the 
 {{% dialog type="code-block" icon="fa fa-code" title="Install kube-lego" %}}
 ```
 chamber write kops KUBE_LEGO_EMAIL devops@example.com
-chamber exec kops -- helmfile -f /conf/kops/helmfile.yaml --selector namespace=kube-system,chart=kube-lego sync
+chamber exec kops -- helmfile -f 0110.kube-lego.yaml sync
 ```
 {{% /dialog %}}
 
@@ -40,7 +40,7 @@ Environment variables can be specified in the Geodesic Module's `Dockerfile` or 
 
 Add to your [Kubernetes Backing Services](/kubernetes-backing-services) Helmfile this code
 
-{{% include-code-block  title="helmfile.yaml" file="kubernetes-backing-services/tls-management/examples/kube-lego-helmfile.yaml" language="yaml" %}}
+{{% include-code-block  title="helmfile" file="kubernetes-backing-services/tls-management/examples/kube-lego-helmfile.yaml" language="yaml" %}}
 
 Then follow the instructions for running [`helmfile sync`]({{< relref "tools/helmfile.md" >}}).
 
@@ -56,7 +56,7 @@ Here are some examples:
 
 {{% include-code-block title="values.yaml" file="kubernetes-backing-services/tls-management/examples/kube-lego-usage-values.yaml" language="yaml" %}}
 
-{{% include-code-block title="helmfile.yaml" file="kubernetes-backing-services/tls-management/examples/kube-lego-usage-helmfile.yaml" language="yaml" %}}
+{{% include-code-block title="helmfile" file="kubernetes-backing-services/tls-management/examples/kube-lego-usage-helmfile.yaml" language="yaml" %}}
 
 {{% dialog type="info" icon="fa-info-circle" title="Note" %}}
 There is no unified specification for helm chart values structure. Different charts may have very different structures to values. The only way to know for sure what is supported is to refer to the chart manifests.

--- a/content/kubernetes-optimization/scale-nginx-ingress-horizontally.md
+++ b/content/kubernetes-optimization/scale-nginx-ingress-horizontally.md
@@ -15,9 +15,9 @@ that uses [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/c
 
 Nginx [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) controller is deployed by [`nginx-ingress`](https://github.com/kubernetes/charts/tree/master/stable/nginx-ingress) [Helm chart]({{< relref "helm-charts/quickstart.md" >}}).
 
-The `nginx-ingress` chart itself is deployed from the `geodesic` shell using the [Master Helmfile](https://github.com/cloudposse/geodesic/blob/master/rootfs/conf/kops/helmfile.yaml).
+The `nginx-ingress` chart itself is deployed from the `geodesic` shell using the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0320.nginx-ingress.yaml).
 
-To scale Nginx Ingress pods horizontally, update the following settings for `nginx-ingress` in the [Master Helmfile](https://github.com/cloudposse/geodesic/blob/master/rootfs/conf/kops/helmfile.yaml):
+To scale Nginx Ingress pods horizontally, update the following settings for `nginx-ingress` in the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0320.nginx-ingress.yaml):
 
 * `replicaCount`
 * `nginx-default-backend.replicaCount`

--- a/content/kubernetes-optimization/scale-nginx-ingress-vertically.md
+++ b/content/kubernetes-optimization/scale-nginx-ingress-vertically.md
@@ -10,7 +10,7 @@ tags:
 - chart
 ---
 
-To scale Nginx Ingress pods vertically, update the following settings for `nginx-ingress` in the [Master Helmfile](https://github.com/cloudposse/geodesic/blob/master/rootfs/conf/kops/helmfile.yaml):
+To scale Nginx Ingress pods vertically, update the following settings for `nginx-ingress` in the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0320.nginx-ingress.yaml):
 
 * `resources.limits.cpu`
 * `resources.limits.memory`

--- a/content/kubernetes-optimization/tune-nginx.md
+++ b/content/kubernetes-optimization/tune-nginx.md
@@ -22,9 +22,9 @@ We optimized Nginx configuration settings to fine-tune Nginx performance in a Ku
 As mentioned above, these settings are stored in the Kubernetes cluster as [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/),
 and get deployed by [`nginx-ingress`](https://github.com/kubernetes/charts/tree/master/stable/nginx-ingress#configuration) [Helm chart]({{< relref "helm-charts/quickstart.md" >}}).
 
-The `nginx-ingress` chart is deployed from the `geodesic` shell using the [Master Helmfile](https://github.com/cloudposse/geodesic/blob/master/rootfs/conf/kops/helmfile.yaml#L496).
+The `nginx-ingress` chart is deployed from the `geodesic` shell using the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0320.nginx-ingress.yaml).
 
-To apply the new Nginx parameters, modify `controller.config` settings in the [Master Helmfile](https://github.com/cloudposse/geodesic/blob/master/rootfs/conf/kops/helmfile.yaml#L496) 
+To apply the new Nginx parameters, modify `controller.config` settings in the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0320.nginx-ingress.yaml) 
 and then follow [`Install with Master Helmfile`]({{< relref "kubernetes-backing-services/ingress/nginx-ingress-controller.md" >}}) instructions to update the cluster with the new Nginx settings.
 
 

--- a/content/kubernetes-platform-services/artifact-storage/chartmuseum.md
+++ b/content/kubernetes-platform-services/artifact-storage/chartmuseum.md
@@ -134,7 +134,7 @@ chamber write kops CHARTMUSEUM_STORAGE_AMAZON_REGION us-west-2
 chamber write kops CHARTMUSEUM_IAM_ROLE example-staging-chart-repo
 chamber write kops CHARTMUSEUM_INGRESS ingress.us-west-2.staging.example.com
 chamber write kops CHARTMUSEUM_HOSTNAME charts.us-west-2.staging.example.com
-chamber exec kops -- helmfile -f 0300.chartmuseum.yaml sync
+chamber exec kops -- helmfile --selector chart=chartmuseum sync
 ```
 {{% /dialog %}}
 

--- a/content/kubernetes-platform-services/artifact-storage/chartmuseum.md
+++ b/content/kubernetes-platform-services/artifact-storage/chartmuseum.md
@@ -70,7 +70,7 @@ To install the `chartmuseum`, you will need to define the `hostname`, which is t
 
 In our example, we use `charts.us-west-2.staging.example.com` as the FQHN. Replace this with an appropriate value to suit your specific project.
 
-You can install `chartmuseum` in a few different ways, but we recommend using the [Master Helmfile](https://github.com/cloudposse/geodesic/blob/master/rootfs/conf/kops/helmfile.yaml).
+You can install `chartmuseum` in a few different ways, but we recommend using the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0300.chartmuseum.yaml).
 
 ### Install with Master Helmfile
 
@@ -134,7 +134,7 @@ chamber write kops CHARTMUSEUM_STORAGE_AMAZON_REGION us-west-2
 chamber write kops CHARTMUSEUM_IAM_ROLE example-staging-chart-repo
 chamber write kops CHARTMUSEUM_INGRESS ingress.us-west-2.staging.example.com
 chamber write kops CHARTMUSEUM_HOSTNAME charts.us-west-2.staging.example.com
-chamber exec kops -- helmfile -f /conf/kops/helmfile.yaml --selector namespace=kube-system,chart=chartmuseum sync
+chamber exec kops -- helmfile -f 0300.chartmuseum.yaml sync
 ```
 {{% /dialog %}}
 
@@ -154,7 +154,7 @@ Environment variables can be specified in the Geodesic Module's `Dockerfile` or 
 
 Add this code to your [Kubernetes Backing Services](/kubernetes-backing-services) Helmfile:
 
-{{% include-code-block  title="helmfile.yaml" file="kubernetes-platform-services/artifact-storage/examples/chart-repo-helmfile.yaml" language="yaml" %}}
+{{% include-code-block  title="helmfile" file="kubernetes-platform-services/artifact-storage/examples/chart-repo-helmfile.yaml" language="yaml" %}}
 
 Then follow the instructions for running [`helmfile sync`]({{< relref "tools/helmfile.md" >}}).
 

--- a/content/kubernetes-platform-services/dashboard/cluster-portal.md
+++ b/content/kubernetes-platform-services/dashboard/cluster-portal.md
@@ -47,11 +47,11 @@ In our example we will use `example-com` as the organization and `staging-team` 
 
 ## Installing on Kubernetes
 
-You can install `portal` in a few different ways, but we recommend using the [Master Helmfile](https://github.com/cloudposse/geodesic/blob/master/rootfs/conf/kops/helmfile.yaml).
+You can install `portal` in a few different ways, but we recommend using the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0620.portal.yaml).
 
 ### Install with Master Helmfile
 
-[Master Helmfile](https://github.com/cloudposse/geodesic/blob/master/rootfs/conf/kops/helmfile.yaml)
+[Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0620.portal.yaml)
 uses GitHub OAuth provider and is configured to expose the following dashboards:
 
 * [Kubernetes Dashboard]({{< relref "kubernetes-platform-services/dashboard/kubernetes-ui-dashboard.md" >}})
@@ -136,7 +136,7 @@ Install the `portal` using `helmfile sync`
 
 Add the following code to your [Kubernetes Backing Services](/kubernetes-backing-services) Helmfile:
 
-{{% include-code-block  title="helmfile.yaml" file="kubernetes-platform-services/dashboard/examples/portal-helmfile.yaml" language="yaml" %}}
+{{% include-code-block  title="helmfile" file="kubernetes-platform-services/dashboard/examples/portal-helmfile.yaml" language="yaml" %}}
 
 {{% include-code-block  title="values/portal.yaml" file="kubernetes-platform-services/dashboard/examples/values-portal.yaml" language="yaml" %}}
 

--- a/content/kubernetes-platform-services/dashboard/examples/portal-helmfile-sync.txt
+++ b/content/kubernetes-platform-services/dashboard/examples/portal-helmfile-sync.txt
@@ -10,4 +10,4 @@ chamber write kops PORTAL_TITLE "Staging Example"
 chamber write kops PORTAL_BRAND "Staging Cluster"
 chamber write kops PORTAL_BRAND_IMAGE_URL "https://cloudposse.com/wp-content/uploads/sites/29/2018/02/SquareLogo2.png"
 chamber write kops PORTAL_BRAND_IMAGE_FAVICON_URL "https://cloudposse.com/wp-content/uploads/sites/29/2018/04/favicon-57.png"
-chamber exec kops -- helmfile -f /conf/kops/helmfile.yaml --selector namespace=monitoring,chart=portal sync
+chamber exec kops -- helmfile -f 0620.portal.yaml sync

--- a/content/kubernetes-platform-services/dashboard/examples/portal-helmfile-sync.txt
+++ b/content/kubernetes-platform-services/dashboard/examples/portal-helmfile-sync.txt
@@ -10,4 +10,4 @@ chamber write kops PORTAL_TITLE "Staging Example"
 chamber write kops PORTAL_BRAND "Staging Cluster"
 chamber write kops PORTAL_BRAND_IMAGE_URL "https://cloudposse.com/wp-content/uploads/sites/29/2018/02/SquareLogo2.png"
 chamber write kops PORTAL_BRAND_IMAGE_FAVICON_URL "https://cloudposse.com/wp-content/uploads/sites/29/2018/04/favicon-57.png"
-chamber exec kops -- helmfile -f 0620.portal.yaml sync
+chamber exec kops -- helmfile --selector chart=portal sync

--- a/content/kubernetes-platform-services/dashboard/kubernetes-ui-dashboard.md
+++ b/content/kubernetes-platform-services/dashboard/kubernetes-ui-dashboard.md
@@ -10,7 +10,7 @@ weight: 1
 
 # Installation
 
-You can install `kubernetes-dashboard` in a few different ways, but we recommend to use the [Master Helmfile](https://github.com/cloudposse/geodesic/blob/master/rootfs/conf/kops/helmfile.yaml).
+You can install `kubernetes-dashboard` in a few different ways, but we recommend to use the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0610.dashboard.yaml).
 
 The Kubernetes dashboard requires [heapster](https://github.com/kubernetes/heapster) to collect and interpret various signals like compute and memory resource usage and lifecycle events.
 
@@ -20,11 +20,9 @@ You can skip `heapster` installation if there is no need to monitor resources.
 
 Run the following commands:
 ```bash
-helmfile -f /conf/kops/helmfile.yaml \
---selector namespace=kube-system,chart=heapster sync
+helmfile -f 0600.heapster.yaml sync
 
-helmfile -f /conf/kops/helmfile.yaml \
---selector namespace=kube-system,chart=kubernetes-dashboard sync
+helmfile -f 0610.dashboard.yaml sync
 ```
 
 These environment variables are used to configure the service:
@@ -39,7 +37,7 @@ Environment variables can be specified in either the Geodesic module's `Dockerfi
 
 Add this code to your [Kubernetes Backing Services](/kubernetes-backing-services) Helmfile
 
-{{% include-code-block  title="helmfile.yaml" file="kubernetes-platform-services/dashboard/examples/kubernetes-dashboard-helmfile.yaml" language="yaml" %}}
+{{% include-code-block  title="helmfile" file="kubernetes-platform-services/dashboard/examples/kubernetes-dashboard-helmfile.yaml" language="yaml" %}}
 
 Then follow the instructions for running [`helmfile sync`]({{< relref "tools/helmfile.md" >}}).
 

--- a/content/kubernetes-platform-services/dashboard/kubernetes-ui-dashboard.md
+++ b/content/kubernetes-platform-services/dashboard/kubernetes-ui-dashboard.md
@@ -20,9 +20,9 @@ You can skip `heapster` installation if there is no need to monitor resources.
 
 Run the following commands:
 ```bash
-helmfile -f 0600.heapster.yaml sync
+helmfile --selector chart=heapster sync
 
-helmfile -f 0610.dashboard.yaml sync
+helmfile --selector chart=kubernetes-dashboard sync
 ```
 
 These environment variables are used to configure the service:

--- a/content/release-engineering/cicd-process/deploy.md
+++ b/content/release-engineering/cicd-process/deploy.md
@@ -15,7 +15,7 @@ We typically store the `helmfile.yaml` in the application repo under the `config
 
 Here's an example of what a typical `helmfile` looks like:
 
-{{% include-code-block title="config/helmfile.yaml" file="release-engineering/cicd-process/examples/app-helmfile.yaml" language="yaml" %}}
+{{% include-code-block title="helmfile" file="release-engineering/cicd-process/examples/app-helmfile.yaml" language="yaml" %}}
 
 Here's an example of what a typical `envsubst` parameterized helm values file looks like:
 

--- a/content/tools/aws-vault.md
+++ b/content/tools/aws-vault.md
@@ -39,7 +39,7 @@ brew cask install aws-vault
 Download the precompiled binary from the GitHub releases page, unless a package exists for your distro.
 
 ```
-sudo curl -o /usr/local/bin/aws-vault https://github.com/99designs/aws-vault/releases/download/v4.2.0/aws-vault-linux-amd64
+sudo curl -L -o /usr/local/bin/aws-vault https://github.com/99designs/aws-vault/releases/download/v4.2.0/aws-vault-linux-amd64
 sudo chmod 755 /usr/local/bin/aws-vault
 ```
 

--- a/content/tools/helmfile.md
+++ b/content/tools/helmfile.md
@@ -50,7 +50,7 @@ Alternatively, set the [`KUBE_CONTEXT`]({{< relref "release-engineering/codefres
 
 The `helmfile.yaml` is a [go-template](https://golang.org/pkg/text/template/) formatted "YAML" file. Note, this means that it is first evaluated as a plain-text go-template before getting processed as YAML. It essential that the go-template result in well-formed YAML with properly escaped values.
 
-For a complex example, review the [Master Helmfile](https://github.com/cloudposse/geodesic/blob/master/rootfs/conf/kops/helmfile.yaml) that ships with `geodesic`.
+For complete examples, review our comprehensive distribution of [helmfiles](https://github.com/cloudposse/helmfiles/tree/master/helmfile.d).
 
 ## Example `helmfile.yaml`
 
@@ -146,4 +146,4 @@ chamber exec $service -- helmfile sync
 
 - [Official Helmfile documentation](https://github.com/roboll/helmfile)
 - [Sprig functions documentation](http://masterminds.github.io/sprig/)
-- [Master Helmfile](https://github.com/cloudposse/geodesic/blob/master/rootfs/conf/kops/helmfile.yaml)
+- [Helmfiles](https://github.com/cloudposse/helmfiles/tree/master/helmfile.d/)


### PR DESCRIPTION
## what
* Add `-L` option to `curl` to install `aws-vault`
* Update links to `helmfiles`

## why
* It should follow GitHub's redirect to the actual binary. Otherwise, it'll just download the HTML redirect response. Required for Windows Subsystem for Linux (WSL)
* `Helmfiles` moved from `geodesic` to https://github.com/cloudposse/helmfiles
