### PR TITLE
Fix Kops command to export k8s cluster config

### DIFF
--- a/content/faq/running-kubectl-fails-connection-refused.md
+++ b/content/faq/running-kubectl-fails-connection-refused.md
@@ -21,11 +21,11 @@ The connection to the server localhost:8080 was refused - did you specify the ri
 
 This is most likely caused by not setting the `kubectl` context to use the kops cluster.
 
-To fix this, run `kubectl export kubecfg --name us-west-2.staging.cloudposse.org` (replace our kops cluster name with yours or use the `$KOPS_CLUSTER_NAME` variable, if set). =)
+To fix this, run `kops export kubecfg` (this assumes the`$KOPS_CLUSTER_NAME` variable is already set to the cluster name)
 
 e.g.
 ```
-kubectl export kubecfg --name $KOPS_CLUSTER_NAME
+kops export kubecfg
 ```
 
 This will export the `kubecfg` to `/dev/shm`, temporary flash memory storage that should get erased when the container exits.

--- a/content/secrets-management/kubernetes.md
+++ b/content/secrets-management/kubernetes.md
@@ -17,9 +17,9 @@ Whether invoking `helm` directly or via `helmfile` all secrets should be passed 
 
 ## Kubernetes API Credentials
 
-The kubernetes TLS keys are stored by `kops` in a private, encrypted S3 bucket. When using the geodesic shell, you'll need to export these credentials in order to access the kubernetes cluster using `kubectl` or `helm`.
+The kubernetes TLS keys are stored by `kops` in a private, encrypted S3 bucket. When using the geodesic shell, you'll need to export these credentials in order to access the kubernetes cluster using `kops` or `helm`.
 
-This is done by running `kubectl export kubecfg $KOPS_CLUSTER_NAME`
+This is done by running `kops export kubecfg`
 
 ## SSH Access
 


### PR DESCRIPTION
This should be `kops export`, `kubectl export` isn’t a thing.