### PR TITLE
Add Kops upgrade cluster notes for `kops validate`

### DIFF
--- a/content/geodesic/kops/upgrade-cluster.md
+++ b/content/geodesic/kops/upgrade-cluster.md
@@ -19,6 +19,11 @@ Then follow the instructions below for upgrading Kubernetes.
 <https://github.com/kubernetes/kops/blob/master/docs/releases.md>
 {{% /dialog %}}
 
+{{% dialog type="important" icon="fa fa-exclamation-triangle" title="Important" %}}
+Before attempting to upgrade any Kops cluster, ensure that it is in a
+healthy state by running [`kops validate cluster`](https://github.com/kubernetes/kops/blob/master/docs/cli/kops_validate.md). If the cluster is not in a healthy state, do not proceed because the `kops rolling-update` process relies on the cluster state in order to determine if it should proceed. For example, if any `Pods` are in a crash loop, we recommend deleting or fixing those apps before attempting any upgrades. 
+{{% /dialog %}}
+
 ## Upgrading Kubernetes Release
 
 Upgrading `kops` cluster to a new release of kubernetes requires that we upgrade the `kubectl` client in `geodesic` as well as select a kubernetes release that is compatible with kops. Note, `kops` usually lags behind in support for the latest release of Kubernetes. If the latest release of `kops` is `v1.9`, then that means it supports up to kubernetes `v1.9` and will not be compatible with `v1.10` or newer.


### PR DESCRIPTION
## what

Upgrading a cluster that is already not passing `kops validate` is not a good idea, we should reflect this in our docs.

![screenshot 2018-12-13 at 10 55 28](https://user-images.githubusercontent.com/3025844/49934222-b3999780-fec5-11e8-855b-77e0c92ab325.png)
