### PR TITLE
Create Design Decisions Category

### DIFF
--- a/content/design-decisions/0001-record-architecture-decisions.md
+++ b/content/design-decisions/0001-record-architecture-decisions.md
@@ -1,0 +1,28 @@
+---
+title: "Record Architecture Decisions"
+date: "2018-12-13" 
+description: "We need to record the architectural decisions made across our projects."
+weight: 1
+---
+
+## Status
+
+**Accepted**
+
+## Context
+
+We need to record the architectural decisions made across our projects for greater transparency and better record keeping. 
+
+Part of the problem is sometimes decisions made today, lack context months or years from now. 
+
+Othertimes, we forget why a particular decision was made when seemingly better alternatives exist. 
+
+## Decision
+
+We will use Architecture Decision Records, as described by [Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions). 
+
+## Consequences
+
+We are going to start by documenting some of our decisions [here](https://github.com/cloudposse/docs), rougly following the process used by [`adr-tools`](https://github.com/npryce/adr-tools). 
+
+These will be decisions that affect our overall strategy, rather than decisions that relate to one particular repository or project.


### PR DESCRIPTION
## what
* Start a "Design Decisions" category

## why
* Allow us to discuss big decisions in an open, collaborative (via GitHub PRs) and transparent manner

## references
* https://github.com/npryce/adr-tools
* http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions