### PR TITLE
links to helmfiles fixed

### DIFF
--- a/content/kubernetes-backing-services/external-dns/external-dns.md
+++ b/content/kubernetes-backing-services/external-dns/external-dns.md
@@ -56,7 +56,7 @@ In the example the iam role name is `kops_external_dns_role_name = example-stagi
 
 ### Install Chart
 
-You can install `external-dns` in a few different ways, but we recommend using the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0100.external-dns.yaml).
+You can install `external-dns` in a few different ways, but we recommend using the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/releases/external-dns.yaml).
 
 ### Install with Master Helmfile
 

--- a/content/kubernetes-backing-services/ingress/nginx-ingress-controller.md
+++ b/content/kubernetes-backing-services/ingress/nginx-ingress-controller.md
@@ -11,7 +11,7 @@ None
 
 ## Install
 
-You can install the `nginx-ingress` controller in few different ways, but we recommend to use the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0320.nginx-ingress.yaml).
+You can install the `nginx-ingress` controller in few different ways, but we recommend to use the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/releases/nginx-ingress.yaml).
 
 ### Install using Master Helmfile
 

--- a/content/kubernetes-backing-services/monitoring/kube-prometheus.md
+++ b/content/kubernetes-backing-services/monitoring/kube-prometheus.md
@@ -29,7 +29,7 @@ Kube Prometheus includes the following packages:
 
 ## Install
 
-You can install `kube-prometheus` in a few different ways, but we recommend to use the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0400.kube-prometheus.yaml).
+You can install `kube-prometheus` in a few different ways, but we recommend to use the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/releases/kube-prometheus.yaml).
 
 ### Install using Helmfile
 

--- a/content/kubernetes-backing-services/monitoring/prometheus-operator.md
+++ b/content/kubernetes-backing-services/monitoring/prometheus-operator.md
@@ -12,7 +12,7 @@ None
 
 ## Install
 
-You can install `prometheus-operator` in a few different ways, but we recommend to use the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0000.prometheus-operator.yaml).
+You can install `prometheus-operator` in a few different ways, but we recommend to use the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/releases/prometheus-operator.yaml).
 
 ### Install using Helmfile
 

--- a/content/kubernetes-backing-services/tls-management/kube-lego-lets-encrypt.md
+++ b/content/kubernetes-backing-services/tls-management/kube-lego-lets-encrypt.md
@@ -13,7 +13,7 @@ Out of the box, `kube-lego` support 2 types of [ingress controllers](https://git
 
 ## Install
 
-You can install `kube-lego` in a few different ways, but we recommend to use the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0110.kube-lego.yaml).
+You can install `kube-lego` in a few different ways, but we recommend to use the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/releases/kube-lego.yaml).
 
 ### Install with Master Helmfile
 

--- a/content/kubernetes-optimization/scale-nginx-ingress-horizontally.md
+++ b/content/kubernetes-optimization/scale-nginx-ingress-horizontally.md
@@ -15,9 +15,9 @@ that uses [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/c
 
 Nginx [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) controller is deployed by [`nginx-ingress`](https://github.com/kubernetes/charts/tree/master/stable/nginx-ingress) [Helm chart]({{< relref "helm-charts/quickstart.md" >}}).
 
-The `nginx-ingress` chart itself is deployed from the `geodesic` shell using the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0320.nginx-ingress.yaml).
+The `nginx-ingress` chart itself is deployed from the `geodesic` shell using the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/releases/nginx-ingress.yaml).
 
-To scale Nginx Ingress pods horizontally, update the following settings for `nginx-ingress` in the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0320.nginx-ingress.yaml):
+To scale Nginx Ingress pods horizontally, update the following settings for `nginx-ingress` in the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/releases/nginx-ingress.yaml):
 
 * `replicaCount`
 * `nginx-default-backend.replicaCount`

--- a/content/kubernetes-optimization/scale-nginx-ingress-vertically.md
+++ b/content/kubernetes-optimization/scale-nginx-ingress-vertically.md
@@ -10,7 +10,7 @@ tags:
 - chart
 ---
 
-To scale Nginx Ingress pods vertically, update the following settings for `nginx-ingress` in the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0320.nginx-ingress.yaml):
+To scale Nginx Ingress pods vertically, update the following settings for `nginx-ingress` in the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/releases/nginx-ingress.yaml):
 
 * `resources.limits.cpu`
 * `resources.limits.memory`

--- a/content/kubernetes-optimization/tune-nginx.md
+++ b/content/kubernetes-optimization/tune-nginx.md
@@ -22,9 +22,9 @@ We optimized Nginx configuration settings to fine-tune Nginx performance in a Ku
 As mentioned above, these settings are stored in the Kubernetes cluster as [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/),
 and get deployed by [`nginx-ingress`](https://github.com/kubernetes/charts/tree/master/stable/nginx-ingress#configuration) [Helm chart]({{< relref "helm-charts/quickstart.md" >}}).
 
-The `nginx-ingress` chart is deployed from the `geodesic` shell using the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0320.nginx-ingress.yaml).
+The `nginx-ingress` chart is deployed from the `geodesic` shell using the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/releases/nginx-ingress.yaml).
 
-To apply the new Nginx parameters, modify `controller.config` settings in the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0320.nginx-ingress.yaml) 
+To apply the new Nginx parameters, modify `controller.config` settings in the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/releases/nginx-ingress.yaml) 
 and then follow [`Install with Master Helmfile`]({{< relref "kubernetes-backing-services/ingress/nginx-ingress-controller.md" >}}) instructions to update the cluster with the new Nginx settings.
 
 

--- a/content/kubernetes-platform-services/artifact-storage/chartmuseum.md
+++ b/content/kubernetes-platform-services/artifact-storage/chartmuseum.md
@@ -70,7 +70,7 @@ To install the `chartmuseum`, you will need to define the `hostname`, which is t
 
 In our example, we use `charts.us-west-2.staging.example.com` as the FQHN. Replace this with an appropriate value to suit your specific project.
 
-You can install `chartmuseum` in a few different ways, but we recommend using the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0300.chartmuseum.yaml).
+You can install `chartmuseum` in a few different ways, but we recommend using the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/releases/chartmuseum.yaml).
 
 #### Install with Master Helmfile
 

--- a/content/kubernetes-platform-services/dashboard/cluster-portal.md
+++ b/content/kubernetes-platform-services/dashboard/cluster-portal.md
@@ -63,11 +63,11 @@ If you are using self-hosted `GitLab` you have to set
 
 ### Installing on Kubernetes
 
-You can install `portal` in a few different ways, but we recommend using the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0620.portal.yaml).
+You can install `portal` in a few different ways, but we recommend using the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/releases/portal.yaml).
 
 #### Install with Master Helmfile
 
-[Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0620.portal.yaml)
+[Helmfile](https://github.com/cloudposse/helmfiles/blob/master/releases/portal.yaml)
 uses GitHub OAuth provider and is configured to expose the following dashboards:
 
 * [Kubernetes Dashboard]({{< relref "kubernetes-platform-services/dashboard/kubernetes-ui-dashboard.md" >}})

--- a/content/kubernetes-platform-services/dashboard/kubernetes-ui-dashboard.md
+++ b/content/kubernetes-platform-services/dashboard/kubernetes-ui-dashboard.md
@@ -10,7 +10,7 @@ weight: 1
 
 ## Installation
 
-You can install `kubernetes-dashboard` in a few different ways, but we recommend to use the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0610.dashboard.yaml).
+You can install `kubernetes-dashboard` in a few different ways, but we recommend to use the [Helmfile](https://github.com/cloudposse/helmfiles/blob/master/releases/dashboard.yaml).
 
 The Kubernetes dashboard requires [heapster](https://github.com/kubernetes/heapster) to collect and interpret various signals like compute and memory resource usage and lifecycle events.
 

--- a/content/tools/helmfile.md
+++ b/content/tools/helmfile.md
@@ -146,4 +146,4 @@ chamber exec $service -- helmfile sync
 
 - [Official Helmfile documentation](https://github.com/roboll/helmfile)
 - [Sprig functions documentation](http://masterminds.github.io/sprig/)
-- [Helmfiles](https://github.com/cloudposse/helmfiles/tree/master/helmfile.d/)
+- [Helmfiles](https://github.com/cloudposse/helmfiles/tree/master/releases/)

--- a/content/tools/helmfile.md
+++ b/content/tools/helmfile.md
@@ -50,7 +50,7 @@ Alternatively, set the [`KUBE_CONTEXT`]({{< relref "release-engineering/codefres
 
 The `helmfile.yaml` is a [go-template](https://golang.org/pkg/text/template/) formatted "YAML" file. Note, this means that it is first evaluated as a plain-text go-template before getting processed as YAML. It essential that the go-template result in well-formed YAML with properly escaped values.
 
-For complete examples, review our comprehensive distribution of [helmfiles](https://github.com/cloudposse/helmfiles/tree/master/helmfile.d).
+For complete examples, review our comprehensive distribution of [helmfiles](https://github.com/cloudposse/helmfiles/tree/master/releases).
 
 ## Example `helmfile.yaml`
 

--- a/content/troubleshooting/kube2iam-assuming-role-access-denied.md
+++ b/content/troubleshooting/kube2iam-assuming-role-access-denied.md
@@ -25,4 +25,4 @@ We've seen this error with `kube2iam` many times due to AWS API rate limiting. I
 
 The only "quick fix" we've seen is to `kubectl drain` drain afflicted node and then terminate it so a new one is spawned in its place. You may need to perform this action repeatedly on all nodes. New nodes will have their rate limits reset to zero, however, this is only a temporary fix and the problem will resurface as soon as limits are exceeded.
 
-The long-term fix is to switch to `kiam`. Our comprehensive distribution of [`helmfiles`](https://github.com/cloudposse/helmfiles) ships with support for [`kiam`](https://github.com/cloudposse/helmfiles/blob/master/helmfile.d/0020.kiam.yaml).
+The long-term fix is to switch to `kiam`. Our comprehensive distribution of [`helmfiles`](https://github.com/cloudposse/helmfiles) ships with support for [`kiam`](https://github.com/cloudposse/helmfiles/blob/master/releases/kiam.yaml).


### PR DESCRIPTION
## What
* links to helmfiles fixed to proper ones

## Why
* helmfiles folder was renamed from `helmfile.d` to `releases`
* helmfiles prefixes was removed in filenames
