### PR TITLE
Update md to have an OS independent section

### DIFF
--- a/content/local-dev-environments/quickstart.md
+++ b/content/local-dev-environments/quickstart.md
@@ -47,6 +47,8 @@ After installing, you'll now see a new docker icon in your task bar.
 Docker for Mac requires OS X El Capitan 10.11 or newer macOS release running on a 2010 or newer Mac, with Intel's hardware support for MMU virtualization.
 {{% /dialog %}}
 
+## OS Independent
+
 ### Configure AWS Vault
 
 Now set up your AWS credentials so you can interact with AWS on the command line.


### PR DESCRIPTION
# Why

AWS Vault is not specific to MacOS.

# What

Creates an `OS Independent` section and moves AWS-Vault.