### PR TITLE
acknowledge '.envrc' usage

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -50,6 +50,8 @@ IgnoreURLs:
 - "github.com/cloudposse/docs/blob"
 # Site started blocking us
 - "blog.gopheracademy.com"
+# x509 certificate has expired:
+- "richard.wallman.org.uk"
 
 # Array of regexs of directories to ignore when scanning for HTML files.
 IgnoreDirs:

--- a/Makefile
+++ b/Makefile
@@ -186,12 +186,10 @@ release:
 		sed 's,^editURL.*,editURL = "$(HUGO_EDIT_URL)",' \
 		> $(HUGO_CONFIG)
 	@echo "Wrote $(HUGO_CONFIG) for $(HUGO_URL)..."
-	@grep -n --color=never . $(HUGO_CONFIG)
 	cat .htmltest.yml | \
 		sed 's,^OutputDir:.*,OutputDir: "$(TMPDIR)/.htmltest",' \
 		> $(HTMLTEST_CONFIG)
 	@echo "Wrote $(HTMLTEST_CONFIG) for codefresh..."
-	@grep -n --color=never . $(HTMLTEST_CONFIG)
 
 ## Deploy static site to S3
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -186,10 +186,12 @@ release:
 		sed 's,^editURL.*,editURL = "$(HUGO_EDIT_URL)",' \
 		> $(HUGO_CONFIG)
 	@echo "Wrote $(HUGO_CONFIG) for $(HUGO_URL)..."
+	@grep -n --color=never . $(HUGO_CONFIG)
 	cat .htmltest.yml | \
 		sed 's,^OutputDir:.*,OutputDir: "$(TMPDIR)/.htmltest",' \
 		> $(HTMLTEST_CONFIG)
 	@echo "Wrote $(HTMLTEST_CONFIG) for codefresh..."
+	@grep -n --color=never . $(HTMLTEST_CONFIG)
 
 ## Deploy static site to S3
 deploy:

--- a/content/geodesic/design.md
+++ b/content/geodesic/design.md
@@ -8,7 +8,7 @@ weight: -1
 
 We designed this shell as the last layer of abstraction. It stitches all the tools together like `make`, `aws-cli`, `kops`, `helm`, `kubectl`, and `terraform`. As time progresses, there will undoubtedly be even more that come into play. For this reason, we chose to use a combination of `bash` and `make` which together are ideally suited to combine the strengths of all these wonderful tools into one powerful shell, without raising the barrier to entry too high.
 
-For the default environment variables, check out `Dockerfile`. We believe using ENVs this way is both consistent with the "cloud" ([12 Factor Pattern]({{< relref "development/12-factor-pattern.md" >}})) way of doing things, as well as a clear way of communicating what values are being passed without using a complicated convention. Additionally, you can set & forget these ENVs in your shell.
+For the default environment variables, check out `.envrc` and `Dockerfile`. We believe using ENVs this way is both consistent with the "cloud" ([12 Factor Pattern]({{< relref "development/12-factor-pattern.md" >}})) way of doing things, as well as a clear way of communicating what values are being passed without using a complicated convention. Additionally, you can set & forget these ENVs in your shell.
 
 ## Layout Inside the Shell
 


### PR DESCRIPTION
## What

Start leaving breadcrumbs in the docs regarding moving ENV vars out of the `Dockerfile` and into `*.envrc` files.