### PR TITLE
Enable build flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ shell: docker/build
 
 ## Build front-end components
 components/build: $(COMPONENTS_DEPS)
-	@echo "Enabled components: $(COMPONENT_DEPS)
+	@echo "Enabled components: $(COMPONENT_DEPS)"
 	@exit 0
 
 ## Generate all static content (outputs to public/) using docker environment

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 
 export OS ?= $(shell uname -s | tr '[:upper:]' '[:lower:]')
+
+export HUGO ?= hugo
 export HUGO_PORT ?= 1313
 export HUGO_URL ?= http://localhost.cloudposse.com:$(HUGO_PORT)/
 export HUGO_EDIT_BRANCH ?= $(GIT_BRANCH)
@@ -68,6 +70,7 @@ shell: docker/build
 
 ## Build front-end components
 components/build: $(COMPONENTS_DEPS)
+	@echo "Enabled components: $(COMPONENT_DEPS)
 	@exit 0
 
 ## Generate all static content (outputs to public/) using docker environment

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ shell: docker/build
 
 ## Build front-end components
 components/build: $(COMPONENTS_DEPS)
-	@echo "Enabled components: $(COMPONENT_DEPS)"
+	@echo "Enabled components: $(COMPONENTS_DEPS)"
 	@exit 0
 
 ## Generate all static content (outputs to public/) using docker environment

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -19,6 +19,7 @@ steps:
     image: cloudposse/build-harness:${{BUILD_HARNESS_VERSION}}
     working_directory: ./
     commands:
+      - set +e -xo pipefail
       - make git/show
       - make git/export | tee -a ${{CF_VOLUME_PATH}}/env_vars_to_export
       - make semver/show
@@ -36,6 +37,7 @@ steps:
     image: '${{build_image}}'
     working_directory: ./
     commands:
+      - set +e -xo pipefail
       - make lint
       - make release
       - make hugo/build
@@ -48,6 +50,7 @@ steps:
       - "HUGO_URL=${{HUGO_URL}}release/${{SEMVERSION_TAG}}"
       - "HUGO_PUBLISH_DIR=public/release/${{SEMVERSION_TAG}}"
     commands:
+      - set +e -xo pipefail
       - make lint
       - make release
       - make hugo/build
@@ -63,6 +66,7 @@ steps:
     environment:
       - "HUGO_EDIT_BRANCH=${{CF_BRANCH}}"
     commands:
+      - set +e -xo pipefail
       - make lint
       - make smoketest
 
@@ -72,6 +76,7 @@ steps:
     image: cloudposse/build-harness:${{BUILD_HARNESS_VERSION}}
     working_directory: ./
     commands:
+      - set +e -xo pipefail
       - make deploy
     when:
       condition:
@@ -84,6 +89,7 @@ steps:
     image: '${{build_image}}'
     working_directory: ./
     commands:
+      - set +e -xo pipefail
       - make reindex
     when:
       condition:
@@ -96,6 +102,7 @@ steps:
     image: '${{build_image}}'
     working_directory: IMAGE_WORK_DIR
     commands:
+      - set +e -xo pipefail
       - make invalidate-cache
     when:
       condition:

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -11,6 +11,8 @@ steps:
       - cf_export HUGO_CONFIG=deploy.toml
       - cf_export HTMLTEST_CONFIG=.htmltest.codefresh.yml
       - cf_export TMPDIR=/codefresh/volume
+      - cf_export YARN_BUILD_DISABLED=false
+      - cf_export COMPONENTS_BUILD=true
 
   semver:
     title: Export semantic version

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -40,7 +40,7 @@ steps:
       - set +e -x
       - make lint
       - make release
-      - make hugo/build
+      - make real-clean hugo/build
 
   build_versioned_release:
     title: Building Hugo static site versioned release...
@@ -53,7 +53,7 @@ steps:
       - set +e -x
       - make lint
       - make release
-      - make hugo/build
+      - make real-clean hugo/build
     when:
       condition:
         all:
@@ -68,7 +68,7 @@ steps:
     commands:
       - set +e -x
       - make lint
-      - make smoketest
+      - make real-clean smoketest
 
   # Only deploy on tagged releases
   deploy:

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -19,7 +19,7 @@ steps:
     image: cloudposse/build-harness:${{BUILD_HARNESS_VERSION}}
     working_directory: ./
     commands:
-      - set +e -xo pipefail
+      - set +e -x
       - make git/show
       - make git/export | tee -a ${{CF_VOLUME_PATH}}/env_vars_to_export
       - make semver/show
@@ -37,7 +37,7 @@ steps:
     image: '${{build_image}}'
     working_directory: ./
     commands:
-      - set +e -xo pipefail
+      - set +e -x
       - make lint
       - make release
       - make hugo/build
@@ -50,7 +50,7 @@ steps:
       - "HUGO_URL=${{HUGO_URL}}release/${{SEMVERSION_TAG}}"
       - "HUGO_PUBLISH_DIR=public/release/${{SEMVERSION_TAG}}"
     commands:
-      - set +e -xo pipefail
+      - set +e -x
       - make lint
       - make release
       - make hugo/build
@@ -66,7 +66,7 @@ steps:
     environment:
       - "HUGO_EDIT_BRANCH=${{CF_BRANCH}}"
     commands:
-      - set +e -xo pipefail
+      - set +e -x
       - make lint
       - make smoketest
 
@@ -76,7 +76,7 @@ steps:
     image: cloudposse/build-harness:${{BUILD_HARNESS_VERSION}}
     working_directory: ./
     commands:
-      - set +e -xo pipefail
+      - set +e -x
       - make deploy
     when:
       condition:
@@ -89,7 +89,7 @@ steps:
     image: '${{build_image}}'
     working_directory: ./
     commands:
-      - set +e -xo pipefail
+      - set +e -x
       - make reindex
     when:
       condition:
@@ -102,7 +102,7 @@ steps:
     image: '${{build_image}}'
     working_directory: IMAGE_WORK_DIR
     commands:
-      - set +e -xo pipefail
+      - set +e -x
       - make invalidate-cache
     when:
       condition:


### PR DESCRIPTION
## what
* Enable build flags so we generate the CSS

## why
* Optimizations made to speed up local development inadvertently disabled generation during CI/CD
* We running old assets in production

## references
* #458 