### PR TITLE
Docs Should Be Full Width if No Subcategories

### DIFF
--- a/themes/cloudposse/src/scss/components/page-elements/page.scss
+++ b/themes/cloudposse/src/scss/components/page-elements/page.scss
@@ -1,5 +1,4 @@
 .page-content {
-  max-width: 1024px;
   scroll-behavior: smooth;
   overflow-y: auto;
   padding: 10px;
@@ -137,6 +136,7 @@
     @include respond-to('desktop') {
       display: flex;
       flex-direction: column;
+      flex-grow: 1;
     }
   }
 

--- a/themes/cloudposse/src/scss/components/page-elements/right-sidebar.scss
+++ b/themes/cloudposse/src/scss/components/page-elements/right-sidebar.scss
@@ -11,6 +11,7 @@
 
   @include respond-to('large') {
     display: block;
+    flex: 1 0 300px;
   }
 
   &__title {


### PR DESCRIPTION
## what
* Changed behaviour when no sidebar on page it takes fullwidth.

