### PR TITLE
using cloudposse-specific repo to install hugo and htmltest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:11.2-stretch
-RUN curl -1sLf 'https://dl.cloudsmith.io/public/cloudposse/packages/setup.deb.sh' | bash
 
+RUN curl -1sLf 'https://dl.cloudsmith.io/public/cloudposse/packages/setup.deb.sh' | bash
 RUN apt-get install hugo htmltest
 
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
-FROM cloudposse/packages:0.93.0 as packages
-
-ENV INSTALL_PATH=/dist
-RUN mkdir -p ${INSTALL_PATH}
-RUN make -C /packages/install hugo HUGO_VERSION=0.42.1
-RUN make -C /packages/install htmltest HTMLTEST_VERSION=0.9.1
-
 FROM node:11.2-stretch
+RUN curl -1sLf 'https://dl.cloudsmith.io/public/cloudposse/packages/setup.deb.sh' | bash
 
-COPY --from=packages /dist/ /usr/local/bin/
+# Forcing install from cloudposse-specific repo.
+RUN sed -i 's/^/#/' /etc/apt/sources.list && \
+    apt-get install hugo htmltest && \
+    sed -i 's/^#//' /etc/apt/sources.list
 
 WORKDIR /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
 FROM node:11.2-stretch
 RUN curl -1sLf 'https://dl.cloudsmith.io/public/cloudposse/packages/setup.deb.sh' | bash
 
-# Forcing install from cloudposse-specific repo.
-RUN sed -i 's/^/#/' /etc/apt/sources.list && \
-    apt-get install hugo htmltest && \
-    sed -i 's/^#//' /etc/apt/sources.list
+RUN apt-get install hugo htmltest
 
 WORKDIR /src
 

--- a/config.toml
+++ b/config.toml
@@ -53,7 +53,7 @@ notAlternative = true
 
 [mediaTypes]
   [mediaTypes."application/algolia"]
-    suffix = "algolia.json"
+    suffixes = ["algolia.json"]
 
 [outputFormats.algolia]
 isPlainText = true

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -3,7 +3,7 @@
 {{- $section := $.Site.GetPage "section" .Section }}
 {{- range .Site.AllPages -}}
   {{- if or (and (.IsDescendant $section) (and (not .Draft) (not .Params.private))) $section.IsHome -}}
-    {{- $.Scratch.Add "index" (dict "objectID" .UniqueID "date" .Date.UTC.Unix "description" (.Description | markdownify | plainify) "dir" .Dir "expirydate" .ExpiryDate.UTC.Unix "fuzzywordcount" .FuzzyWordCount "keywords" .Keywords "kind" .Kind "lang" .Lang "lastmod" .Lastmod.UTC.Unix "permalink" .Permalink "publishdate" .PublishDate "readingtime" .ReadingTime "relpermalink" .RelPermalink "summary" (.Summary | markdownify | plainify) "title" .Title "type" .Type "url" .URL "weight" .Weight "wordcount" .WordCount "section" .Section "tags" .Params.Tags "categories" .Params.Categories "authors" .Params.Authors)}}
+    {{- $.Scratch.Add "index" (dict "objectID" .File.UniqueID "date" .Date.UTC.Unix "description" (.Description | markdownify | plainify) "dir" .File.Dir "expirydate" .ExpiryDate.UTC.Unix "fuzzywordcount" .FuzzyWordCount "keywords" .Keywords "kind" .Kind "lang" .Lang "lastmod" .Lastmod.UTC.Unix "permalink" .Permalink "publishdate" .PublishDate "readingtime" .ReadingTime "relpermalink" .RelPermalink "summary" (.Summary | markdownify | plainify) "title" .Title "type" .Type "url" .URL "weight" .Weight "wordcount" .WordCount "section" .Section "tags" .Params.Tags "categories" .Params.Categories "authors" .Params.Authors)}}
   {{- end -}}
 {{- end -}}
 {{- $.Scratch.Get "index" | jsonify -}}

--- a/layouts/partials/flex/head.html
+++ b/layouts/partials/flex/head.html
@@ -5,7 +5,7 @@
 <meta http-equiv="refresh" content="0;url={{ .Page.Params.redirect | absURL }}" />
 {{- end -}}
 
-{{ .Hugo.Generator }}
+{{ hugo.Generator }}
 <title>{{ .Title }}&nbsp;&mdash;&nbsp;{{ .Site.Title }}</title>
 <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700,900" rel="stylesheet">
 <link rel="shortcut icon" href="{{"images/favicon.png" | relURL}}" type="image/x-icon" />

--- a/tasks/Makefile.hugo
+++ b/tasks/Makefile.hugo
@@ -10,5 +10,5 @@ hugo/run: components/build
 hugo/build: components/build
 	@[ "$(HUGO_PUBLISH_DIR)" != "/" ] || (echo "Invalid HUGO_PUBLISH_DIR=$(HUGO_PUBLISH_DIR)"; exit 1)
 	rm -rf $(HUGO_PUBLISH_DIR)
-	$(DOCKER_RUN) hugo --templateMetrics --trace /dev/stdout --config $(HUGO_CONFIG)
+	$(DOCKER_RUN) hugo --templateMetrics --config $(HUGO_CONFIG)
 

--- a/tasks/Makefile.hugo
+++ b/tasks/Makefile.hugo
@@ -10,6 +10,6 @@ hugo/run: components/build
 hugo/build: components/build
 	@[ "$(HUGO_PUBLISH_DIR)" != "/" ] || (echo "Invalid HUGO_PUBLISH_DIR=$(HUGO_PUBLISH_DIR)"; exit 1)
 	rm -rf $(HUGO_PUBLISH_DIR)
-	$(DOCKER_RUN) hugo --templateMetrics --stepAnalysis --config $(HUGO_CONFIG)
+	$(DOCKER_RUN) hugo --templateMetrics --trace trace.out --config $(HUGO_CONFIG)
 
 

--- a/tasks/Makefile.hugo
+++ b/tasks/Makefile.hugo
@@ -10,6 +10,5 @@ hugo/run: components/build
 hugo/build: components/build
 	@[ "$(HUGO_PUBLISH_DIR)" != "/" ] || (echo "Invalid HUGO_PUBLISH_DIR=$(HUGO_PUBLISH_DIR)"; exit 1)
 	rm -rf $(HUGO_PUBLISH_DIR)
-	$(DOCKER_RUN) hugo --templateMetrics --trace trace.out --config $(HUGO_CONFIG)
-
+	$(DOCKER_RUN) hugo --templateMetrics --trace /dev/stdout --config $(HUGO_CONFIG)
 


### PR DESCRIPTION
## what
* The `cloudposse/docs` Docker image will now install `hugo` and `htmltest` from a CloudPosse-controlled repo ultimately being fed by `cloudposse/packages`.

## why
* This integrates `cloudposse/docs` with `cloudposse/packages` and removes any version maintenance burden on `hugo` and `htmltest` for the `cloudposse/docs` maintainers.

## references
* https://cloudposse.atlassian.net/browse/CPCO-416
* https://github.com/gohugoio/hugo/issues/7480
