### PR TITLE
adding draft-release github actions workflow from cloudposse/geodesic

### DIFF
--- a/.github/draft-release.yml
+++ b/.github/draft-release.yml
@@ -1,0 +1,67 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+version-template: '$MAJOR.$MINOR.$PATCH'
+version-resolver:
+  major:
+    labels:
+    - 'major'
+  minor:
+    labels:
+    - 'minor'
+    - 'enhancement'
+  patch:
+    labels:
+    - 'auto-update'
+    - 'patch'
+    - 'fix'
+    - 'bugfix'
+    - 'bug'
+    - 'hotfix'
+    - 'packages'
+    - 'docker'
+    - 'docs'
+    - 'github'
+  default: 'minor'
+
+categories:
+- title: '🚀 Enhancements'
+  labels:
+  - 'enhancement'
+  - 'patch'
+  - 'shell'
+  - 'scripts'
+  - 'terraform'
+- title: '🐛 Bug Fixes'
+  labels:
+  - 'fix'
+  - 'bugfix'
+  - 'bug'
+  - 'hotfix'
+- title: '🧰 Included Tools'
+  labels:
+  - 'packages'
+  - 'docker'
+- title: '📚️ Documentation'
+  labels:
+  - 'docs'
+- title: '🏗️ Build/Release Maintenance'
+  labels:
+  - 'github'
+
+change-template: |
+  <details>
+    <summary>$TITLE @$AUTHOR (#$NUMBER)</summary>
+
+    $BODY
+  </details>
+
+template: |
+  $CHANGES
+
+replacers:
+# Remove irrelevant information from Renovate bot
+- search: '/---\s+^#.*Renovate configuration(?:.|\n)*?This PR has been generated .*/gm'
+  replace: ''
+# Remove Renovate bot banner image
+- search: '/\[!\[[^\]]*Renovate\][^\]]*\](\([^)]*\))?\s*\n+/gm'
+  replace: ''

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,19 @@
+name: draft-release
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  semver:
+    runs-on: ubuntu-latest
+    steps:
+    # Drafts your next Release notes as Pull Requests are merged into "master"
+    - uses: release-drafter/release-drafter@v5
+      with:
+        publish: false
+        prerelease: false
+        config-name: draft-release.yml
+      env:
+        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}


### PR DESCRIPTION
## what
* Copied draft-release github action workflow from `cloudposse/geodesic`.

## why
* Gives us a jumpstart on writing release notes for future releases.

## references
* https://cloudposse.atlassian.net/browse/CPCO-425