### PR TITLE
GitHub Action to Collate Documentation from External Repos

### DIFF
--- a/.github/workflows/github-pages-deployment.yml
+++ b/.github/workflows/github-pages-deployment.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         content: docs,modules
         config: |
-          .baseURL=test.url
+          .baseURL="test.url"
           .enableEmoji="absolutely"
         hugo_url: https://cloudposse.github.io/docs
         github_pages_pull_branch: master

--- a/.github/workflows/github-pages-deployment.yml
+++ b/.github/workflows/github-pages-deployment.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         content: docs,modules
         config: |
-          .baseURL="test.url"
+          .baseURL=test.url
           .enableEmoji="absolutely"
         hugo_url: https://cloudposse.github.io/docs
         github_pages_pull_branch: master

--- a/.github/workflows/github-pages-deployment.yml
+++ b/.github/workflows/github-pages-deployment.yml
@@ -27,17 +27,17 @@ jobs:
     - name: "Build Documentation Website Locally"
       uses: cloudposse/docs/actions/publish-github-pages@publish-gh-pages-python
       with:
-        CONTENT: docs,modules
-        HUGO_URL: https://cloudposse.github.io/docs
-        HUGO_PUBLISH_DIR: docs
-        HUGO_CONFIG: hugo.config.new.yml # this variable is the output location, not the input template location
-        HTMLTEST_CONFIG: .htmltest.new.yml # this variable is the output location, not the input template location
-        STAGING_DIR: /tmp/staging
-        GITHUB_PAGES_PULL_BRANCH: github-pages-docs
-        GITHUB_PAGES_HUGO_PATH: /tmp/hugo
-        GITHUB_PAGES_REPO: ${{ env.GITHUB_PAGES_REPO }}
-        GITHUB_PAGES_PUSH_BRANCH: ${{ env.GITHUB_PAGES_PUSH_BRANCH }}
-        GITHUB_PAGES_DIRECTORY: ${{ env.GITHUB_PAGES_DIRECTORY }}
+        content: docs,modules
+        hugo_url: https://cloudposse.github.io/docs
+        hugo_publish_dir: docs
+        hugo_config: hugo.config.new.yml # this variable is the output location, not the input template location
+        htmltest_config: .htmltest.new.yml # this variable is the output location, not the input template location
+        staging_dir: /tmp/staging
+        github_pages_pull_branch: github-pages-docs
+        github_pages_hugo_path: /tmp/hugo
+        github_pages_repo: ${{ env.GITHUB_PAGES_REPO }}
+        github_pages_push_branch: ${{ env.GITHUB_PAGES_PUSH_BRANCH }}
+        github_pages_directory: ${{ env.GITHUB_PAGES_DIRECTORY }}
     - name: "Deploy Documentation Website to GitHub Pages"
       uses: cloudposse/actions/github/git-push@0.30.0
       env:

--- a/.github/workflows/github-pages-deployment.yml
+++ b/.github/workflows/github-pages-deployment.yml
@@ -24,9 +24,9 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
-    - name: "Collate documentation"
+    - name: "Build Documentation Website Locally"
       uses: cloudposse/docs/actions/publish-github-pages@publish-gh-pages-python
-      env:
+      with:
         CONTENT: docs,modules
         HUGO_URL: https://cloudposse.github.io/docs
         HUGO_PUBLISH_DIR: docs
@@ -35,7 +35,10 @@ jobs:
         STAGING_DIR: /tmp/staging
         GITHUB_PAGES_PULL_BRANCH: github-pages-docs
         GITHUB_PAGES_HUGO_PATH: /tmp/hugo
-    - name: "Deploy Hugo Static Site to GitHub Pages"
+        GITHUB_PAGES_REPO: ${{ env.GITHUB_PAGES_REPO }}
+        GITHUB_PAGES_PUSH_BRANCH: ${{ env.GITHUB_PAGES_PUSH_BRANCH }}
+        GITHUB_PAGES_DIRECTORY: ${{ env.GITHUB_PAGES_DIRECTORY }}
+    - name: "Deploy Documentation Website to GitHub Pages"
       uses: cloudposse/actions/github/git-push@0.30.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github-pages-deployment.yml
+++ b/.github/workflows/github-pages-deployment.yml
@@ -19,7 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAGES_REPO: https://github.com/cloudposse/docs
-      GITHUB_PAGES_PULL_BRANCH: master
       GITHUB_PAGES_PUSH_BRANCH: production
       GITHUB_PAGES_DIRECTORY: github_pages
     steps:
@@ -33,8 +32,9 @@ jobs:
         HUGO_PUBLISH_DIR: docs
         HUGO_CONFIG: hugo.config.new.yml # this variable is the output location, not the input template location
         HTMLTEST_CONFIG: .htmltest.new.yml # this variable is the output location, not the input template location
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
+        STAGING_DIR: /tmp/staging
+        GITHUB_PAGES_PULL_BRANCH: github-pages-docs
+        GITHUB_PAGES_HUGO_PATH: /tmp/hugo
     - name: "Deploy Hugo Static Site to GitHub Pages"
       uses: cloudposse/actions/github/git-push@0.30.0
       env:

--- a/.github/workflows/github-pages-deployment.yml
+++ b/.github/workflows/github-pages-deployment.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       GITHUB_PAGES_REPO: https://github.com/cloudposse/docs
       GITHUB_PAGES_PUSH_BRANCH: production
-      GITHUB_PAGES_DIRECTORY: github_pages
+      GITHUB_PAGES_PUSH_PATH: github_pages
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
@@ -29,20 +29,15 @@ jobs:
       with:
         content: docs,modules
         hugo_url: https://cloudposse.github.io/docs
-        hugo_publish_dir: docs
-        hugo_config: hugo.config.new.yml # this variable is the output location, not the input template location
-        htmltest_config: .htmltest.new.yml # this variable is the output location, not the input template location
-        staging_dir: /tmp/staging
         github_pages_pull_branch: github-pages-docs
-        github_pages_hugo_path: /tmp/hugo
         github_pages_repo: ${{ env.GITHUB_PAGES_REPO }}
         github_pages_push_branch: ${{ env.GITHUB_PAGES_PUSH_BRANCH }}
-        github_pages_directory: ${{ env.GITHUB_PAGES_DIRECTORY }}
+        github_pages_push_path: ${{ env.GITHUB_PAGES_PUSH_PATH }}
     - name: "Deploy Documentation Website to GitHub Pages"
       uses: cloudposse/actions/github/git-push@0.30.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
-        GITHUB_REPOSITORY: env.GITHUB_PAGES_REPO
-        GIT_DIRECTORY: ./${{ env.GITHUB_PAGES_DIRECTORY }}/
+        GITHUB_REPOSITORY: ${{ env.GITHUB_PAGES_REPO }}
+        GIT_DIRECTORY: ${{ env.GITHUB_PAGES_PUSH_PATH }}
         GIT_BRANCH: ${{ env.GITHUB_PAGES_PUSH_BRANCH }}

--- a/.github/workflows/github-pages-deployment.yml
+++ b/.github/workflows/github-pages-deployment.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         content: docs,modules
         hugo_url: https://cloudposse.github.io/docs
-        github_pages_pull_branch: github-pages-docs
+        github_pages_pull_branch: master
         github_pages_repo: ${{ env.GITHUB_PAGES_REPO }}
         github_pages_push_branch: ${{ env.GITHUB_PAGES_PUSH_BRANCH }}
         github_pages_push_path: ${{ env.GITHUB_PAGES_PUSH_PATH }}

--- a/.github/workflows/github-pages-deployment.yml
+++ b/.github/workflows/github-pages-deployment.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
-    - name: "Build Hugo Static Site"
+    - name: "Collate documentation"
       uses: cloudposse/docs/actions/publish-github-pages@publish-gh-pages-python
       env:
         CONTENT: docs,modules

--- a/.github/workflows/github-pages-deployment.yml
+++ b/.github/workflows/github-pages-deployment.yml
@@ -30,7 +30,7 @@ jobs:
         content: docs,modules
         config: |
           .baseURL="test.url"
-          .enableEmoij="absolutely"
+          .enableEmoji="absolutely"
         hugo_url: https://cloudposse.github.io/docs
         github_pages_pull_branch: master
         github_pages_repo: ${{ env.GITHUB_PAGES_REPO }}

--- a/.github/workflows/github-pages-deployment.yml
+++ b/.github/workflows/github-pages-deployment.yml
@@ -28,6 +28,9 @@ jobs:
       uses: cloudposse/docs/actions/publish-github-pages@publish-gh-pages-python
       with:
         content: docs,modules
+        config: |
+          baseURL="test.url"
+          enableEmoij="absolutely"
         hugo_url: https://cloudposse.github.io/docs
         github_pages_pull_branch: master
         github_pages_repo: ${{ env.GITHUB_PAGES_REPO }}

--- a/.github/workflows/github-pages-deployment.yml
+++ b/.github/workflows/github-pages-deployment.yml
@@ -29,8 +29,8 @@ jobs:
       with:
         content: docs,modules
         config: |
-          baseURL="test.url"
-          enableEmoij="absolutely"
+          .baseURL="test.url"
+          .enableEmoij="absolutely"
         hugo_url: https://cloudposse.github.io/docs
         github_pages_pull_branch: master
         github_pages_repo: ${{ env.GITHUB_PAGES_REPO }}

--- a/actions/publish-github-pages/README.md
+++ b/actions/publish-github-pages/README.md
@@ -1,0 +1,146 @@
+# CloudPosse's "Publish Docs to GitHub Pages" GitHub Action
+
+Publish auto-generated documentation on your repo to a GitHub Pages site.
+
+## Conceptual Background
+
+### Repositories
+
+This GitHub Action brings together three different repositories:
+
+1. A repository containing all of the resources needed to compile a Hugo (https://gohugo.io/) static site  
+
+Relevant inputs: `hugo_repo`, `hugo_branch`
+
+2. A repository containing for which a documentation website should be built  
+
+Relevant inputs: `github_pages_repo`, `github_pages_pull_branch`
+
+3. A repository which is setup to deploy to GitHub Pages (https://pages.github.com/)  
+
+Relevant inputs: `github_pages_repo`, `github_pages_push_branch`
+
+NB: For now, repositories `2` and `3` are just different branches of the same repository (assumed to be the repository this GitHub Action is being executed from). This is because, in general, this GitHub Action would require special GitHub tokens in order to pull/push from other repositories.
+
+### Environment inside the GitHub Actions runner
+
+There are 5 folders of interest inside the GitHub Actions runner:
+
+1. The local copy of the `hugo_repo`  
+
+Relevant input: `github_pages_hugo_path`
+
+2. The local copy of the `github_pages_pull_branch` of the `github_pages_repo`  
+
+Relevant input: `github_pages_pull_path`
+
+3. The staging directory, where the essential Hugo build files from `hugo_repo` will be combined with the documentation files from the `github_pages_pull_branch` of the `github_pages_repo`  
+
+Relevant input: `staging_dir`
+
+4. The build directory, where all of the HTML, CSS, etc. file for the documentation website will be written  
+
+Relevant input: `hugo_publish_dir`
+
+5. The local copy of the `github_pages_push_branch` of the `github_pages_repo`  
+
+Relevant input: `github_pages_push_path`
+
+The general flow of files in this workflow is `1 & 2` -> `3` -> `4` -> `5`.
+
+### Website Configuration and Build Process Configuration
+
+Please see `action.yml` for descriptions of the following configuration inputs: `content`, `hugo_url`, `css`, `config`, `debug`, `hugo_content`, `hugo_config`, `htmltest_config`
+
+## Usage
+
+1. Set up your credentials as secrets in your repository settings using `TWILIO_ACCOUNT_SID`, `TWILIO_API_KEY`, `TWILIO_API_SECRET`
+
+2. Add the following to your workflow
+
+```yml
+- name: 'Sending SMS Notification'
+  uses: twilio-labs/actions-sms@v1
+  with:
+    fromPhoneNumber: '+1(234)5678901'
+    toPhoneNumber: '+1(234)3334444'
+    message: 'Hello from Twilio'
+  env:
+    TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
+    TWILIO_API_KEY: ${{ secrets.TWILIO_API_KEY }}
+    TWILIO_API_SECRET: ${{ secrets.TWILIO_API_SECRET }}
+```
+
+## Inputs
+
+### `content`
+
+**Required** Comma-separated list of directories in the top level of the repo that contains documentation
+
+### `hugo_url`
+
+**Required** URL of the Hugo site after deployment
+
+### `github_pages_push_path`
+
+**Required** Location where the repo/branch that deploys to GitHub Pages will be cloned
+
+### `github_pages_pull_branch`
+
+**Required** The branch of the repo which contains the documentation
+
+### `github_pages_repo`
+
+**Required** Repo containing documentation to be deployed to GitHub Pages
+
+### `github_pages_push_branch`
+
+**Required** The branch of the repo which GitHub Pages will deploy from
+
+### `css`
+
+**Required** Custom CSS to customize the look and feel of the docs website
+
+### `config`
+
+**Required** Hugo YAML configuration overrides. The overrides should be either space- or newline-separated and must follow the following conventions. They must provide a YAML path in dot notation, have an equals sign, and have the override value be quoted, all with no interior spaces. E.g., .baseURL="test.url.com" enableEmoji="True"
+
+### `debug`
+
+Toggle to turn on any available debug functionality
+
+### `hugo_content`
+
+Folders of generic documentation to build into the final docs website. Default: "tutorials,howto,fundamentals,reference"
+
+### `hugo_publish_dir`
+
+Directory within the staging directory that the built Hugo website files will be written to. Default: "docs"
+
+### `hugo_config`
+
+Location of to-be-written Hugo config file (actual location not important). Default: "hugo.config.new.yml"
+
+### `htmltest_config`
+
+Location to write the htmltest config file (actual location not important). Default: ".htmltest.new.yml"
+
+### `hugo_repo`
+
+Repo containing Hugo build files. Default: "https://github.com/cloudposse/docs"
+
+### `hugo_branch`
+
+Branch of hugo_repo containing Hugo build files. Default: "master"
+
+### `github_pages_hugo_path`
+
+Location where the repo containing the Hugo files will be cloned.
+
+### `github_pages_pull_path`
+
+Location where the repo/branch containing the raw documentation will be cloned. Default: "/tmp/pull"
+
+### `staging_dir`
+
+Directory where all documentation files will be combined with Hugo configuration files, and the Hugo site will be built. Default: "/tmp/staging"

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -35,7 +35,7 @@ inputs:
     description: 'The branch of the repo which contains the documentation'
     required: false
   staging_dir:
-    description: 'directory to collate all docs and Hugo files in'
+    description: 'Directory to collate all docs and Hugo configuration files'
     required: false
 runs:
   using: 'composite'

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -25,6 +25,10 @@ inputs:
   debug:
     description: 'Toggle to turn on debug functionality'
     required: false
+  hugo_content:
+    description: "Folders of generic documentation to build into the final docs website"
+    required: false
+    default: "tutorials,howto,fundamentals,reference"
   hugo_publish_dir:
     description: >
       Directory within the staging directory that the built Hugo website files will be written to
@@ -97,6 +101,7 @@ runs:
         STAGING_DIR: ${{ inputs.staging_dir }}
         DEBUG: ${{ inputs.debug }}
         CONTENT: ${{ inputs.content }}
+        HUGO_CONTENT: ${{ inputs.hugo_content }}
     - name: "Build Hugo Site Locally"
       run: |
         docker build -t cloudposse/docs .

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -22,11 +22,14 @@ inputs:
   css:
     description: 'Custom CSS to customize the look and feel'
     required: false
+  config:
+    description: 'Hugo YAML configuration overrides'
+    required: false
   debug:
     description: 'Toggle to turn on debug functionality'
     required: false
   hugo_content:
-    description: "Folders of generic documentation to build into the final docs website"
+    description: 'Folders of generic documentation to build into the final docs website'
     required: false
     default: "tutorials,howto,fundamentals,reference"
   hugo_publish_dir:
@@ -86,12 +89,6 @@ runs:
         GITHUB_PAGES_PULL_BRANCH: ${{ inputs.github_pages_pull_branch }}
         GITHUB_PAGES_PUSH_PATH: ${{ inputs.github_pages_push_path }}
         GITHUB_PAGES_PUSH_BRANCH: ${{ inputs.github_pages_push_branch }}
-    - name: "Append Custom CSS"
-      run: echo -e "$CSS" >> ${GITHUB_PAGES_HUGO_PATH}/themes/cloudposse/src/scss/custom.scss
-      shell: bash
-      env:
-        CSS: ${{ inputs.css }}
-        GITHUB_PAGES_HUGO_PATH: ${{ inputs.github_pages_hugo_path }}
     - name: "Collate Documentation Files"
       run: pip install GitPython pyyaml && python collate.py
       shell: bash
@@ -102,6 +99,18 @@ runs:
         DEBUG: ${{ inputs.debug }}
         CONTENT: ${{ inputs.content }}
         HUGO_CONTENT: ${{ inputs.hugo_content }}
+    - name: "Append Custom CSS"
+      run: echo -e "$CSS" >> ./themes/cloudposse/src/scss/custom.scss
+      shell: bash
+      working-directory: ${{ inputs.staging_dir }}
+      env:
+        CSS: ${{ inputs.css }}
+    - name: "Customize Hugo YAML Config"
+      run: yq $CONFIG config.yaml
+      shell: bash
+      working-directory: ${{ inputs.staging_dir }}
+      env:
+        CONFIG: ${{ inputs.config }}
     - name: "Build Hugo Site Locally"
       run: |
         docker build -t cloudposse/docs .

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -4,6 +4,9 @@ inputs:
   CONTENT:
     description: 'comma-separated list of directories in the top level of the repo that contains documentation'
     required: false
+  CSS:
+    description: 'custom CSS to insert into custom.scss'
+    required: false
   DEBUG:
     description: 'whether to turn on debug printouts/functionality'
     required: false
@@ -25,6 +28,9 @@ inputs:
   GITHUB_ACTOR:
     description: 'github actor'
     required: false
+  GITHUB_PAGES_HUGO_PATH:
+    description: 'location where the repo containing the Hugo files will be checked out to'
+    required: false
   GITHUB_PAGES_PULL_BRANCH:
     description: 'the branch of the repo which contains the documentation'
     required: false
@@ -43,8 +49,18 @@ runs:
         PYTHONPATH: ${{ github.action_path }}
         GITHUB_PAGES_PUSH_PATH: ${{ github.action_path }}/${{ env.GITHUB_PAGES_DIRECTORY }}
         INPUT_GITHUB_PAGES_PULL_BRANCH: ${{ inputs.GITHUB_PAGES_PULL_BRANCH }}
+        INPUT_GITHUB_PAGES_HUGO_PATH: ${{ inputs.GITHUB_PAGES_HUGO_PATH }}
         INPUT_DEBUG: ${{ inputs.DEBUG }}
         INPUT_STAGING_DIR: ${{ inputs.STAGING_DIR }}
+    - id: insert-custom-css
+      run: |
+           export CSS=${CSS:-$INPUT_CSS}
+           export GITHUB_PAGES_HUGO_PATH=${GITHUB_PAGES_HUGO_PATH:-$INPUT_GITHUB_PAGES_HUGO_PATH}
+           echo -e "\n$CSS" >> ${GITHUB_PAGES_HUGO_PATH}/themes/cloudposse/src/scss/custom.scss
+      shell: bash
+      env:
+        INPUT_CSS: ${{ inputs.CSS }}
+        INPUT_GITHUB_PAGES_HUGO_PATH: ${{ inputs.GITHUB_PAGES_HUGO_PATH }}
     - id: collate-files
       run: |
            pip install GitPython pyyaml
@@ -53,6 +69,7 @@ runs:
       env:
         PYTHONPATH: ${{ github.action_path }}
         GITHUB_PAGES_PUSH_PATH: ${{ github.action_path }}/${{ env.GITHUB_PAGES_DIRECTORY }}
+        INPUT_GITHUB_PAGES_HUGO_PATH: ${{ inputs.GITHUB_PAGES_HUGO_PATH }}
         INPUT_GITHUB_PAGES_PULL_BRANCH: ${{ inputs.GITHUB_PAGES_PULL_BRANCH }}
         INPUT_DEBUG: ${{ inputs.DEBUG }}
         INPUT_CONTENT: ${{ inputs.CONTENT }}

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -28,81 +28,62 @@ inputs:
   GITHUB_PAGES_PULL_BRANCH:
     description: 'the branch of the repo which contains the documentation'
     required: false
+  STAGING_DIR:
+    description: 'directory to collate all docs and Hugo files in'
+    required: false
 runs:
   using: 'composite'
   steps:
     - id: checkout-repos
       run: |
            pip install GitPython pyyaml
-           python -c 'from collate import *; checkout_repos()'
+           python -c 'from checkout_and_collate import *; checkout_repos()'
       shell: bash
       env:
         PYTHONPATH: ${{ github.action_path }}
-        STAGING_DIR: /tmp/staging
-        INPUT_CONTENT: ${{ inputs.CONTENT }}
-        INPUT_DEBUG: ${{ inputs.DEBUG }}
-        INPUT_HUGO_URL: ${{ inputs.HUGO_URL }}
-        INPUT_HUGO_PUBLISH_DIR: ${{ inputs.HUGO_PUBLISH_DIR }}
-        INPUT_HUGO_CONFIG: ${{ inputs.HUGO_CONFIG }}
-        INPUT_HTMLTEST_CONFIG: ${{ inputs.HTMLTEST_CONFIG }}
-        INPUT_GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
-        INPUT_GITHUB_ACTOR: ${{ inputs.GITHUB_ACTOR }}
-        INPUT_GITHUB_PAGES_PULL_BRANCH: ${{ inputs.GITHUB_PAGES_PULL_BRANCH }}
         GITHUB_PAGES_PUSH_PATH: ${{ github.action_path }}/${{ env.GITHUB_PAGES_DIRECTORY }}
+        INPUT_GITHUB_PAGES_PULL_BRANCH: ${{ inputs.GITHUB_PAGES_PULL_BRANCH }}
+        INPUT_DEBUG: ${{ inputs.DEBUG }}
+        INPUT_STAGING_DIR: ${{ inputs.STAGING_DIR }}
     - id: collate-files
       run: |
            pip install GitPython pyyaml
-           python -c 'from collate import *; collation_steps()'
+           python -c 'from checkout_and_collate import *; collate_files()'
       shell: bash
       env:
         PYTHONPATH: ${{ github.action_path }}
-        STAGING_DIR: /tmp/staging
-        INPUT_CONTENT: ${{ inputs.CONTENT }}
-        INPUT_DEBUG: ${{ inputs.DEBUG }}
-        INPUT_HUGO_URL: ${{ inputs.HUGO_URL }}
-        INPUT_HUGO_PUBLISH_DIR: ${{ inputs.HUGO_PUBLISH_DIR }}
-        INPUT_HUGO_CONFIG: ${{ inputs.HUGO_CONFIG }}
-        INPUT_HTMLTEST_CONFIG: ${{ inputs.HTMLTEST_CONFIG }}
-        INPUT_GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
-        INPUT_GITHUB_ACTOR: ${{ inputs.GITHUB_ACTOR }}
-        INPUT_GITHUB_PAGES_PULL_BRANCH: ${{ inputs.GITHUB_PAGES_PULL_BRANCH }}
         GITHUB_PAGES_PUSH_PATH: ${{ github.action_path }}/${{ env.GITHUB_PAGES_DIRECTORY }}
+        INPUT_GITHUB_PAGES_PULL_BRANCH: ${{ inputs.GITHUB_PAGES_PULL_BRANCH }}
+        INPUT_DEBUG: ${{ inputs.DEBUG }}
+        INPUT_CONTENT: ${{ inputs.CONTENT }}
+        INPUT_STAGING_DIR: ${{ inputs.STAGING_DIR }}
     - id: build-hugo
       run: |
            # These variables need to be defined manually when GitHub Actions variables are passed in using
            # with: instead of env: in order for the next steps to work.
+           export HUGO_URL=${HUGO_URL:-$INPUT_HUGO_URL}
            export HUGO_CONFIG=${HUGO_CONFIG:-$INPUT_HUGO_CONFIG}
            export HTMLTEST_CONFIG=${HTMLTEST_CONFIG:-$INPUT_HTMLTEST_CONFIG}
            export HUGO_PUBLISH_DIR=${HUGO_PUBLISH_DIR:-$INPUT_HUGO_PUBLISH_DIR}
+           export STAGING_DIR=${STAGING_DIR:-$INPUT_STAGING_DIR}
            cd $STAGING_DIR
            docker build -t cloudposse/docs .
            make release
            make real-clean hugo/build
       shell: bash
       env:
-        STAGING_DIR: /tmp/staging
-        INPUT_CONTENT: ${{ inputs.CONTENT }}
-        INPUT_DEBUG: ${{ inputs.DEBUG }}
+        INPUT_STAGING_DIR: ${{ inputs.STAGING_DIR }}
         INPUT_HUGO_URL: ${{ inputs.HUGO_URL }}
         INPUT_HUGO_PUBLISH_DIR: ${{ inputs.HUGO_PUBLISH_DIR }}
         INPUT_HUGO_CONFIG: ${{ inputs.HUGO_CONFIG }}
         INPUT_HTMLTEST_CONFIG: ${{ inputs.HTMLTEST_CONFIG }}
-        INPUT_GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
-        INPUT_GITHUB_ACTOR: ${{ inputs.GITHUB_ACTOR }}
-        INPUT_GITHUB_PAGES_PULL_BRANCH: ${{ inputs.GITHUB_PAGES_PULL_BRANCH }}
-        GITHUB_PAGES_PUSH_PATH: ${{ github.action_path }}/${{ env.GITHUB_PAGES_DIRECTORY }}
     - id: publish-site
-      run: cp -r ${STAGING_DIR}/${HUGO_PUBLISH_DIR} ${GITHUB_PAGES_PUSH_PATH}
+      run: |
+           export STAGING_DIR=${STAGING_DIR:-$INPUT_STAGING_DIR}
+           export HUGO_PUBLISH_DIR=${HUGO_PUBLISH_DIR:-$INPUT_HUGO_PUBLISH_DIR}
+           cp -r ${STAGING_DIR}/${HUGO_PUBLISH_DIR} ${GITHUB_PAGES_PUSH_PATH}
       shell: bash
       env:
-        STAGING_DIR: /tmp/staging
-        INPUT_CONTENT: ${{ inputs.CONTENT }}
-        INPUT_DEBUG: ${{ inputs.DEBUG }}
-        INPUT_HUGO_URL: ${{ inputs.HUGO_URL }}
+        INPUT_STAGING_DIR: ${{ inputs.STAGING_DIR }}
         INPUT_HUGO_PUBLISH_DIR: ${{ inputs.HUGO_PUBLISH_DIR }}
-        INPUT_HUGO_CONFIG: ${{ inputs.HUGO_CONFIG }}
-        INPUT_HTMLTEST_CONFIG: ${{ inputs.HTMLTEST_CONFIG }}
-        INPUT_GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
-        INPUT_GITHUB_ACTOR: ${{ inputs.GITHUB_ACTOR }}
-        INPUT_GITHUB_PAGES_PULL_BRANCH: ${{ inputs.GITHUB_PAGES_PULL_BRANCH }}
         GITHUB_PAGES_PUSH_PATH: ${{ github.action_path }}/${{ env.GITHUB_PAGES_DIRECTORY }}

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -2,7 +2,7 @@ name: 'Publish GitHub Pages'
 description: 'Publish the Hugo-based Cloud Posse docs website to GitHub Pages.'
 inputs:
   content:
-    description: 'comma-separated list of directories in the top level of the repo that contains documentation'
+    description: 'Comma-separated list of directories in the top level of the repo that contains documentation'
     required: false
   css:
     description: 'Custom CSS to customize the look and feel'

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -108,7 +108,7 @@ runs:
     - name: "Customize Hugo YAML Config"
       run: |
         curl -1sLf 'https://dl.cloudsmith.io/public/cloudposse/packages/setup.deb.sh' | sudo bash
-        apt-get install yq
+        sudo apt-get install yq
         yq $CONFIG config.yaml
         rm setup.deb.sh
       shell: bash

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -52,7 +52,7 @@ runs:
         INPUT_GITHUB_PAGES_HUGO_PATH: ${{ inputs.GITHUB_PAGES_HUGO_PATH }}
         INPUT_DEBUG: ${{ inputs.DEBUG }}
         INPUT_STAGING_DIR: ${{ inputs.STAGING_DIR }}
-    - id: insert-custom-css
+    - id: append-custom-css
       run: |
            export CSS=${CSS:-$INPUT_CSS}
            export GITHUB_PAGES_HUGO_PATH=${GITHUB_PAGES_HUGO_PATH:-$INPUT_GITHUB_PAGES_HUGO_PATH}

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -17,7 +17,7 @@ inputs:
     description: 'Directory in the repo that GitHub Pages will deploy to'
     required: false
   hugo_config:
-    description: 'location of to-be-written Hugo config file (actual location not important)'
+    description: 'Location of to-be-written Hugo config file (actual location not important)'
     required: false
   htmltest_config:
     description: 'location of to-be-written htmltest config file (actual location not important)'

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: 'Location to write the htmltest config file (actual location not important)'
     required: false
   github_token:
-    description: 'github token'
+    description: 'GitHub token'
     required: false
   github_actor:
     description: 'github actor'

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -3,40 +3,43 @@ description: 'Publish the Hugo-based Cloud Posse docs website to GitHub Pages.'
 inputs:
   content:
     description: 'Comma-separated list of directories in the top level of the repo that contains documentation'
-    required: false
+    required: true
   css:
     description: 'Custom CSS to customize the look and feel'
-    required: false
+    required: true
   debug:
     description: 'Toggle to turn on debug functionality'
-    required: false
+    required: true
   hugo_url:
     description: 'URL of the Hugo site after deployment'
-    required: false
+    required: true
   hugo_publish_dir:
     description: 'Directory in the repo that GitHub Pages will deploy to'
-    required: false
+    required: true
   hugo_config:
     description: 'Location of to-be-written Hugo config file (actual location not important)'
-    required: false
+    required: true
   htmltest_config:
     description: 'Location to write the htmltest config file (actual location not important)'
-    required: false
-  github_token:
-    description: 'GitHub token'
-    required: false
-  github_actor:
-    description: 'GitHub Actor'
-    required: false
+    required: true
   github_pages_hugo_path:
     description: 'Location where the repo containing the Hugo files will be cloned'
-    required: false
+    required: true
   github_pages_pull_branch:
     description: 'The branch of the repo which contains the documentation'
-    required: false
+    required: true
   staging_dir:
     description: 'Directory to collate all docs and Hugo configuration files'
-    required: false
+    required: true
+  github_pages_repo:
+    description: 'Repo containing documentation to be deployed to GitHub Pages'
+    required: true
+  github_pages_push_branch:
+    description: 'The branch of the repo which GitHub Pages will deploy to'
+    required: true
+  github_pages_directory:
+    description: 'The directory to write the rendered website files to (should not be an absolute path)'
+    required: true
 runs:
   using: 'composite'
   steps:

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -109,14 +109,11 @@ runs:
       run: |
         curl -1sLf 'https://dl.cloudsmith.io/public/cloudposse/packages/setup.deb.sh' | sudo bash
         sudo apt-get install yq
-        echo "config: $CONFIG"
         for SUBSTITUTION in $CONFIG
         do
           echo $SUBSTITUTION
           yq e -i $SUBSTITUTION config.yaml
         done
-        echo "catting config.yaml:"
-        cat config.yaml
       shell: bash
       working-directory: ${{ inputs.staging_dir }}
       env:

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -66,6 +66,7 @@ runs:
            export HTMLTEST_CONFIG=${HTMLTEST_CONFIG:-$INPUT_HTMLTEST_CONFIG}
            export HUGO_PUBLISH_DIR=${HUGO_PUBLISH_DIR:-$INPUT_HUGO_PUBLISH_DIR}
            export STAGING_DIR=${STAGING_DIR:-$INPUT_STAGING_DIR}
+           echo "staging_dir: $STAGING_DIR"
            cd $STAGING_DIR
            docker build -t cloudposse/docs .
            make release

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -110,10 +110,11 @@ runs:
         curl -1sLf 'https://dl.cloudsmith.io/public/cloudposse/packages/setup.deb.sh' | sudo bash
         sudo apt-get install yq
         echo "config: $CONFIG"
-        echo $CONFIG > config_file.txt
-        echo "config_file.txt:"
-        cat config_file.txt
-        yq e -i $CONFIG config.yaml
+        for SUBSTITUTION in $CONFIG
+        do
+          echo $SUBSTITUTION
+          yq e -i $SUBSTITUTION config.yaml
+        done
         echo "catting config.yaml:"
         cat config.yaml
         rm setup.deb.sh

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -78,7 +78,7 @@ runs:
         HUGO_BRANCH: ${{ inputs.hugo_branch }}
         GITHUB_PAGES_HUGO_PATH: ${{ inputs.github_pages_hugo_path }}
         GITHUB_PAGES_REPO: ${{ inputs.github_pages_repo }}
-        GITHUB_PAGES_PULL_PATH: ${{ inputs:github_pages_pull_path }}
+        GITHUB_PAGES_PULL_PATH: ${{ inputs.github_pages_pull_path }}
         GITHUB_PAGES_PULL_BRANCH: ${{ inputs.github_pages_pull_branch }}
         GITHUB_PAGES_PUSH_PATH: ${{ inputs.github_pages_push_path }}
         GITHUB_PAGES_PUSH_BRANCH: ${{ inputs.github_pages_push_branch }}

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -45,8 +45,8 @@ runs:
   steps:
     - name: "Checkout All Repos"
       run: |
-           pip install GitPython pyyaml
-           python -c 'from checkout_and_collate import *; checkout_repos()'
+        pip install GitPython pyyaml
+        python -c 'from checkout_and_collate import *; checkout_repos()'
       shell: bash
       env:
         PYTHONPATH: ${{ github.action_path }}
@@ -56,18 +56,15 @@ runs:
         DEBUG: ${{ inputs.debug }}
         STAGING_DIR: ${{ inputs.staging_dir }}
     - name: "Append Custom CSS"
-      run: |
-           export CSS=${CSS:-$INPUT_CSS}
-           export GITHUB_PAGES_HUGO_PATH=${GITHUB_PAGES_HUGO_PATH:-$INPUT_GITHUB_PAGES_HUGO_PATH}
-           echo -e "$CSS" >> ${GITHUB_PAGES_HUGO_PATH}/themes/cloudposse/src/scss/custom.scss
+      run: echo -e "$CSS" >> ${GITHUB_PAGES_HUGO_PATH}/themes/cloudposse/src/scss/custom.scss
       shell: bash
       env:
         CSS: ${{ inputs.css }}
         GITHUB_PAGES_HUGO_PATH: ${{ inputs.github_pages_hugo_path }}
     - name: "Collate Documentation Files"
       run: |
-           pip install GitPython pyyaml
-           python -c 'from checkout_and_collate import *; collate_files()'
+        pip install GitPython pyyaml
+        python -c 'from checkout_and_collate import *; collate_files()'
       shell: bash
       env:
         PYTHONPATH: ${{ github.action_path }}
@@ -79,29 +76,18 @@ runs:
         STAGING_DIR: ${{ inputs.staging_dir }}
     - name: "Build Hugo Site Locally"
       run: |
-           # These variables need to be defined manually when GitHub Actions variables are passed in using
-           # with: instead of env: in order for the next steps to work.
-           export HUGO_URL=${HUGO_URL:-$INPUT_HUGO_URL}
-           export HUGO_CONFIG=${HUGO_CONFIG:-$INPUT_HUGO_CONFIG}
-           export HTMLTEST_CONFIG=${HTMLTEST_CONFIG:-$INPUT_HTMLTEST_CONFIG}
-           export HUGO_PUBLISH_DIR=${HUGO_PUBLISH_DIR:-$INPUT_HUGO_PUBLISH_DIR}
-           export STAGING_DIR=${STAGING_DIR:-$INPUT_STAGING_DIR}
-           cd $STAGING_DIR
-           docker build -t cloudposse/docs .
-           make release
-           make real-clean hugo/build
+        docker build -t cloudposse/docs .
+        make release
+        make real-clean hugo/build
       shell: bash
+      working-directory: ${{ inputs.staging_dir }}
       env:
-        STAGING_DIR: ${{ inputs.staging_dir }}
         HUGO_URL: ${{ inputs.hugo_url }}
         HUGO_PUBLISH_DIR: ${{ inputs.hugo_publish_dir }}
         HUGO_CONFIG: ${{ inputs.hugo_config }}
         HTMLTEST_CONFIG: ${{ inputs.htmltest_config }}
     - name: "Move Hugo Site Files to Publishing Directory"
-      run: |
-           export STAGING_DIR=${STAGING_DIR:-$INPUT_STAGING_DIR}
-           export HUGO_PUBLISH_DIR=${HUGO_PUBLISH_DIR:-$INPUT_HUGO_PUBLISH_DIR}
-           cp -r ${STAGING_DIR}/${HUGO_PUBLISH_DIR} ${GITHUB_PAGES_PUSH_PATH}
+      run: cp -r ${STAGING_DIR}/${HUGO_PUBLISH_DIR} ${GITHUB_PAGES_PUSH_PATH}
       shell: bash
       env:
         STAGING_DIR: ${{ inputs.staging_dir }}

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -7,6 +7,18 @@ inputs:
   hugo_url:
     description: 'URL of the Hugo site after deployment'
     required: true
+  github_pages_push_path:
+    description: 'Location where the repo/branch that deploys to GitHub Pages will be cloned'
+    required: true
+  github_pages_pull_branch:
+    description: 'The branch of the repo which contains the documentation'
+    required: true
+  github_pages_repo:
+    description: 'Repo containing documentation to be deployed to GitHub Pages'
+    required: true
+  github_pages_push_branch:
+    description: 'The branch of the repo which GitHub Pages will deploy from'
+    required: true
   css:
     description: 'Custom CSS to customize the look and feel'
     required: false
@@ -17,7 +29,7 @@ inputs:
     description: >
       Directory within the staging directory that the built Hugo website files will be written to
     required: false
-    deafult: "docs"
+    default: "docs"
   hugo_config:
     description: 'Location of to-be-written Hugo config file (actual location not important)'
     required: false
@@ -42,24 +54,12 @@ inputs:
     description: 'Location where the repo/branch containing the raw documentation will be cloned'
     required: false
     default: "/tmp/pull"
-  github_pages_push_path:
-    description: 'Location where the repo/branch that deploys to GitHub Pages will be cloned'
-    required: true
-  github_pages_pull_branch:
-    description: 'The branch of the repo which contains the documentation'
-    required: true
   staging_dir:
     description: >
       Directory where all documentation files will be combined with Hugo configuration files, and
       the Hugo site will be built
     required: false
     default: "/tmp/staging"
-  github_pages_repo:
-    description: 'Repo containing documentation to be deployed to GitHub Pages'
-    required: true
-  github_pages_push_branch:
-    description: 'The branch of the repo which GitHub Pages will deploy from'
-    required: true
 runs:
   using: 'composite'
   steps:

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -32,7 +32,7 @@ inputs:
     description: 'Location where the repo containing the Hugo files will be cloned'
     required: false
   github_pages_pull_branch:
-    description: 'the branch of the repo which contains the documentation'
+    description: 'The branch of the repo which contains the documentation'
     required: false
   staging_dir:
     description: 'directory to collate all docs and Hugo files in'

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -1,40 +1,40 @@
 name: 'Publish GitHub Pages'
 description: 'Publish the Hugo-based Cloud Posse docs website to GitHub Pages.'
 inputs:
-  CONTENT:
+  content:
     description: 'comma-separated list of directories in the top level of the repo that contains documentation'
     required: false
-  CSS:
+  css:
     description: 'custom CSS to insert into custom.scss'
     required: false
-  DEBUG:
+  debug:
     description: 'whether to turn on debug printouts/functionality'
     required: false
-  HUGO_URL:
+  hugo_url:
     description: 'URL of the Hugo site after deployment'
     required: false
-  HUGO_PUBLISH_DIR:
+  hugo_publish_dir:
     description: 'directory in the repo that GitHub Pages will deploy to'
     required: false
-  HUGO_CONFIG:
+  hugo_config:
     description: 'location of to-be-written Hugo config file (actual location not important)'
     required: false
-  HTMLTEST_CONFIG:
+  htmltest_config:
     description: 'location of to-be-written htmltest config file (actual location not important)'
     required: false
-  GITHUB_TOKEN:
+  github_token:
     description: 'github token'
     required: false
-  GITHUB_ACTOR:
+  github_actor:
     description: 'github actor'
     required: false
-  GITHUB_PAGES_HUGO_PATH:
+  github_pages_hugo_path:
     description: 'location where the repo containing the Hugo files will be checked out to'
     required: false
-  GITHUB_PAGES_PULL_BRANCH:
+  github_pages_pull_branch:
     description: 'the branch of the repo which contains the documentation'
     required: false
-  STAGING_DIR:
+  staging_dir:
     description: 'directory to collate all docs and Hugo files in'
     required: false
 runs:
@@ -57,6 +57,7 @@ runs:
            export CSS=${CSS:-$INPUT_CSS}
            export GITHUB_PAGES_HUGO_PATH=${GITHUB_PAGES_HUGO_PATH:-$INPUT_GITHUB_PAGES_HUGO_PATH}
            echo -e "\n$CSS" >> ${GITHUB_PAGES_HUGO_PATH}/themes/cloudposse/src/scss/custom.scss
+           cat ${GITHUB_PAGES_HUGO_PATH}/themes/cloudposse/src/scss/custom.scss
       shell: bash
       env:
         INPUT_CSS: ${{ inputs.CSS }}

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -66,7 +66,6 @@ runs:
            export HTMLTEST_CONFIG=${HTMLTEST_CONFIG:-$INPUT_HTMLTEST_CONFIG}
            export HUGO_PUBLISH_DIR=${HUGO_PUBLISH_DIR:-$INPUT_HUGO_PUBLISH_DIR}
            export STAGING_DIR=${STAGING_DIR:-$INPUT_STAGING_DIR}
-           echo "staging_dir: $STAGING_DIR"
            cd $STAGING_DIR
            docker build -t cloudposse/docs .
            make release

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -34,10 +34,7 @@ runs:
     - id: checkout-repos
       run: |
            pip install GitPython pyyaml
-           echo "RUNNER_DIR: ${RUNNER_DIR}" && echo "pwd: $(pwd)"
-           echo "whoami: $(whoami)" && echo "groups: $(groups)"
-           python -c "import sys; print(f'search path: {sys.path}'); import os; print(f'folder: {sys.path[1]}, contents: {os.listdir(sys.path[1])}'); from collate import *; checkout_repos()"
-           #python -c 'from collate import *; checkout_repos()'
+           python -c 'from collate import *; checkout_repos()'
       shell: bash
       env:
         PYTHONPATH: ${{ github.action_path }}
@@ -55,9 +52,7 @@ runs:
     - id: collate-files
       run: |
            pip install GitPython pyyaml
-           cd $RUNNER_DIR
            python -c 'from collate import *; collation_steps()'
-           #python ${{ github.action_path }}/collate.py
       shell: bash
       env:
         PYTHONPATH: ${{ github.action_path }}

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -107,7 +107,7 @@ runs:
         CSS: ${{ inputs.css }}
     - name: "Customize Hugo YAML Config"
       run: |
-        curl -1sLf 'https://dl.cloudsmith.io/public/cloudposse/packages/setup.deb.sh' | bash
+        curl -1sLf 'https://dl.cloudsmith.io/public/cloudposse/packages/setup.deb.sh' | sudo bash
         apt-get install yq
         yq $CONFIG config.yaml
         rm setup.deb.sh

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: 'Custom CSS to customize the look and feel'
     required: false
   debug:
-    description: 'whether to turn on debug printouts/functionality'
+    description: 'Toggle to turn on debug functionality'
     required: false
   hugo_url:
     description: 'URL of the Hugo site after deployment'

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -50,11 +50,11 @@ runs:
       shell: bash
       env:
         PYTHONPATH: ${{ github.action_path }}
-        GITHUB_PAGES_PUSH_PATH: ${{ github.action_path }}/${{ env.GITHUB_PAGES_DIRECTORY }}
-        INPUT_GITHUB_PAGES_PULL_BRANCH: ${{ inputs.GITHUB_PAGES_PULL_BRANCH }}
-        INPUT_GITHUB_PAGES_HUGO_PATH: ${{ inputs.GITHUB_PAGES_HUGO_PATH }}
-        INPUT_DEBUG: ${{ inputs.DEBUG }}
-        INPUT_STAGING_DIR: ${{ inputs.STAGING_DIR }}
+        GITHUB_PAGES_PUSH_PATH: ${{ github.action_path }}/${{ inputs.github_pages_directory }}
+        GITHUB_PAGES_PULL_BRANCH: ${{ inputs.github_pages_pull_branch }}
+        GITHUB_PAGES_HUGO_PATH: ${{ inputs.github_pages_hugo_path }}
+        DEBUG: ${{ inputs.debug }}
+        STAGING_DIR: ${{ inputs.staging_dir }}
     - name: "Append Custom CSS"
       run: |
            export CSS=${CSS:-$INPUT_CSS}
@@ -62,8 +62,8 @@ runs:
            echo -e "$CSS" >> ${GITHUB_PAGES_HUGO_PATH}/themes/cloudposse/src/scss/custom.scss
       shell: bash
       env:
-        INPUT_CSS: ${{ inputs.CSS }}
-        INPUT_GITHUB_PAGES_HUGO_PATH: ${{ inputs.GITHUB_PAGES_HUGO_PATH }}
+        CSS: ${{ inputs.css }}
+        GITHUB_PAGES_HUGO_PATH: ${{ inputs.github_pages_hugo_path }}
     - name: "Collate Documentation Files"
       run: |
            pip install GitPython pyyaml
@@ -71,12 +71,12 @@ runs:
       shell: bash
       env:
         PYTHONPATH: ${{ github.action_path }}
-        GITHUB_PAGES_PUSH_PATH: ${{ github.action_path }}/${{ env.GITHUB_PAGES_DIRECTORY }}
-        INPUT_GITHUB_PAGES_HUGO_PATH: ${{ inputs.GITHUB_PAGES_HUGO_PATH }}
-        INPUT_GITHUB_PAGES_PULL_BRANCH: ${{ inputs.GITHUB_PAGES_PULL_BRANCH }}
-        INPUT_DEBUG: ${{ inputs.DEBUG }}
-        INPUT_CONTENT: ${{ inputs.CONTENT }}
-        INPUT_STAGING_DIR: ${{ inputs.STAGING_DIR }}
+        GITHUB_PAGES_PUSH_PATH: ${{ github.action_path }}/${{ inputs.github_pages_directory }}
+        GITHUB_PAGES_HUGO_PATH: ${{ inputs.github_pages_hugo_path }}
+        GITHUB_PAGES_PULL_BRANCH: ${{ inputs.github_pages_pull_branch }}
+        DEBUG: ${{ inputs.debug }}
+        CONTENT: ${{ inputs.content }}
+        STAGING_DIR: ${{ inputs.staging_dir }}
     - name: "Build Hugo Site Locally"
       run: |
            # These variables need to be defined manually when GitHub Actions variables are passed in using
@@ -92,11 +92,11 @@ runs:
            make real-clean hugo/build
       shell: bash
       env:
-        INPUT_STAGING_DIR: ${{ inputs.STAGING_DIR }}
-        INPUT_HUGO_URL: ${{ inputs.HUGO_URL }}
-        INPUT_HUGO_PUBLISH_DIR: ${{ inputs.HUGO_PUBLISH_DIR }}
-        INPUT_HUGO_CONFIG: ${{ inputs.HUGO_CONFIG }}
-        INPUT_HTMLTEST_CONFIG: ${{ inputs.HTMLTEST_CONFIG }}
+        STAGING_DIR: ${{ inputs.staging_dir }}
+        HUGO_URL: ${{ inputs.hugo_url }}
+        HUGO_PUBLISH_DIR: ${{ inputs.hugo_publish_dir }}
+        HUGO_CONFIG: ${{ inputs.hugo_config }}
+        HTMLTEST_CONFIG: ${{ inputs.htmltest_config }}
     - name: "Move Hugo Site Files to Publishing Directory"
       run: |
            export STAGING_DIR=${STAGING_DIR:-$INPUT_STAGING_DIR}
@@ -104,6 +104,6 @@ runs:
            cp -r ${STAGING_DIR}/${HUGO_PUBLISH_DIR} ${GITHUB_PAGES_PUSH_PATH}
       shell: bash
       env:
-        INPUT_STAGING_DIR: ${{ inputs.STAGING_DIR }}
-        INPUT_HUGO_PUBLISH_DIR: ${{ inputs.HUGO_PUBLISH_DIR }}
-        GITHUB_PAGES_PUSH_PATH: ${{ github.action_path }}/${{ env.GITHUB_PAGES_DIRECTORY }}
+        STAGING_DIR: ${{ inputs.staging_dir }}
+        HUGO_PUBLISH_DIR: ${{ inputs.hugo_publish_dir }}
+        GITHUB_PAGES_PUSH_PATH: ${{ github.action_path }}/${{ inputs.github_pages_directory }}

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -89,7 +89,7 @@ runs:
         CSS: ${{ inputs.css }}
         GITHUB_PAGES_HUGO_PATH: ${{ inputs.github_pages_hugo_path }}
     - name: "Collate Documentation Files"
-      run: pip install GitPython pyyaml && python -c collate.py
+      run: pip install GitPython pyyaml && python collate.py
       shell: bash
       working-directory: ${{ github.action_path }}
       env:

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -109,7 +109,9 @@ runs:
       run: |
         curl -1sLf 'https://dl.cloudsmith.io/public/cloudposse/packages/setup.deb.sh' | sudo bash
         sudo apt-get install yq
-        yq $CONFIG config.yaml
+        echo "config: $CONFIG"
+        yq e -i $CONFIG config.yaml
+        cat config.yaml
         rm setup.deb.sh
       shell: bash
       working-directory: ${{ inputs.staging_dir }}

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -117,7 +117,6 @@ runs:
         done
         echo "catting config.yaml:"
         cat config.yaml
-        rm setup.deb.sh
       shell: bash
       working-directory: ${{ inputs.staging_dir }}
       env:

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -110,7 +110,7 @@ runs:
         curl -1sLf 'https://dl.cloudsmith.io/public/cloudposse/packages/setup.deb.sh' | sudo bash
         sudo apt-get install yq
         echo "config: $CONFIG"
-        yq e -i "$CONFIG" config.yaml
+        yq e -i $CONFIG config.yaml
         echo "catting config.yaml:"
         cat config.yaml
         rm setup.deb.sh

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -110,6 +110,9 @@ runs:
         curl -1sLf 'https://dl.cloudsmith.io/public/cloudposse/packages/setup.deb.sh' | sudo bash
         sudo apt-get install yq
         echo "config: $CONFIG"
+        echo $CONFIG > config_file.txt
+        echo "config_file.txt:"
+        cat config_file.txt
         yq e -i $CONFIG config.yaml
         echo "catting config.yaml:"
         cat config.yaml

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -85,7 +85,6 @@ runs:
            export STAGING_DIR=${STAGING_DIR:-$INPUT_STAGING_DIR}
            cd $STAGING_DIR
            docker build -t cloudposse/docs .
-           make lint
            make release
            make real-clean hugo/build
       shell: bash

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -67,6 +67,7 @@ runs:
            #python ${{ github.action_path }}/collate.py
       shell: bash
       env:
+        RUNNER_DIR: ${{ github.action_path }}
         STAGING_DIR: /tmp/staging
         INPUT_CONTENT: ${{ inputs.CONTENT }}
         INPUT_DEBUG: ${{ inputs.DEBUG }}

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -20,13 +20,17 @@ inputs:
     description: 'The branch of the repo which GitHub Pages will deploy from'
     required: true
   css:
-    description: 'Custom CSS to customize the look and feel'
+    description: 'Custom CSS to customize the look and feel of the docs website'
     required: false
   config:
-    description: 'Hugo YAML configuration overrides'
+    description: >
+      Hugo YAML configuration overrides. The overrides should be either space- or
+      newline-separated and must follow the following conventions. They must provide a YAML path
+      in dot notation, have an equals sign, and have the override value be quoted, all with no
+      interior spaces. E.g., .baseURL="test.url.com" enableEmoji="true"
     required: false
   debug:
-    description: 'Toggle to turn on debug functionality'
+    description: 'Toggle to turn on any available debug functionality'
     required: false
   hugo_content:
     description: 'Folders of generic documentation to build into the final docs website'

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -4,57 +4,84 @@ inputs:
   content:
     description: 'Comma-separated list of directories in the top level of the repo that contains documentation'
     required: true
-  css:
-    description: 'Custom CSS to customize the look and feel'
-    required: true
-  debug:
-    description: 'Toggle to turn on debug functionality'
-    required: true
   hugo_url:
     description: 'URL of the Hugo site after deployment'
     required: true
+  css:
+    description: 'Custom CSS to customize the look and feel'
+    required: false
+  debug:
+    description: 'Toggle to turn on debug functionality'
+    required: false
   hugo_publish_dir:
-    description: 'Directory in the repo that GitHub Pages will deploy to'
-    required: true
+    description: >
+      Directory within the staging directory that the built Hugo website files will be written to
+    required: false
+    deafult: "docs"
   hugo_config:
     description: 'Location of to-be-written Hugo config file (actual location not important)'
-    required: true
+    required: false
+    default: "hugo.config.new.yml"
   htmltest_config:
     description: 'Location to write the htmltest config file (actual location not important)'
-    required: true
+    required: false
+    default: ".htmltest.new.yml"
+  hugo_repo:
+    description: 'Repo containing Hugo build files'
+    required: false
+    default: "https://github.com/cloudposse/docs"
+  hugo_branch:
+    description: 'Branch of hugo_repo containing Hugo build files'
+    required: false
+    default: "master"
   github_pages_hugo_path:
     description: 'Location where the repo containing the Hugo files will be cloned'
+    required: false
+    default: "/tmp/hugo"
+  github_pages_pull_path:
+    description: 'Location where the repo/branch containing the raw documentation will be cloned'
+    required: false
+    default: "/tmp/pull"
+  github_pages_push_path:
+    description: 'Location where the repo/branch that deploys to GitHub Pages will be cloned'
     required: true
   github_pages_pull_branch:
     description: 'The branch of the repo which contains the documentation'
     required: true
   staging_dir:
-    description: 'Directory to collate all docs and Hugo configuration files'
-    required: true
+    description: >
+      Directory where all documentation files will be combined with Hugo configuration files, and
+      the Hugo site will be built
+    required: false
+    default: "/tmp/staging"
   github_pages_repo:
     description: 'Repo containing documentation to be deployed to GitHub Pages'
     required: true
   github_pages_push_branch:
-    description: 'The branch of the repo which GitHub Pages will deploy to'
-    required: true
-  github_pages_directory:
-    description: 'The directory to write the rendered website files to (should not be an absolute path)'
+    description: 'The branch of the repo which GitHub Pages will deploy from'
     required: true
 runs:
   using: 'composite'
   steps:
     - name: "Checkout All Repos"
       run: |
-        pip install GitPython pyyaml
-        python -c 'from checkout_and_collate import *; checkout_repos()'
+        # Check out
+        # 1) Essential Hugo build tools
+        git clone --branch ${HUGO_BRANCH} $HUGO_REPO $GITHUB_PAGES_HUGO_PATH
+        # 2) Site-specific documentation
+        git clone --branch $GITHUB_PAGES_PULL_BRANCH $GITHUB_PAGES_REPO $GITHUB_PAGES_PULL_PATH
+        # 3) The GitHub Pages deployment branch for this site
+        git clone --branch $GITHUB_PAGES_PUSH_BRANCH $GITHUB_PAGES_REPO $GITHUB_PAGES_PUSH_PATH
       shell: bash
       env:
-        PYTHONPATH: ${{ github.action_path }}
-        GITHUB_PAGES_PUSH_PATH: ${{ github.action_path }}/${{ inputs.github_pages_directory }}
-        GITHUB_PAGES_PULL_BRANCH: ${{ inputs.github_pages_pull_branch }}
+        HUGO_REPO: ${{ inputs.hugo_repo }}
+        HUGO_BRANCH: ${{ inputs.hugo_branch }}
         GITHUB_PAGES_HUGO_PATH: ${{ inputs.github_pages_hugo_path }}
-        DEBUG: ${{ inputs.debug }}
-        STAGING_DIR: ${{ inputs.staging_dir }}
+        GITHUB_PAGES_REPO: ${{ inputs.github_pages_repo }}
+        GITHUB_PAGES_PULL_PATH: ${{ inputs:github_pages_pull_path }}
+        GITHUB_PAGES_PULL_BRANCH: ${{ inputs.github_pages_pull_branch }}
+        GITHUB_PAGES_PUSH_PATH: ${{ inputs.github_pages_push_path }}
+        GITHUB_PAGES_PUSH_BRANCH: ${{ inputs.github_pages_push_branch }}
     - name: "Append Custom CSS"
       run: echo -e "$CSS" >> ${GITHUB_PAGES_HUGO_PATH}/themes/cloudposse/src/scss/custom.scss
       shell: bash
@@ -62,18 +89,14 @@ runs:
         CSS: ${{ inputs.css }}
         GITHUB_PAGES_HUGO_PATH: ${{ inputs.github_pages_hugo_path }}
     - name: "Collate Documentation Files"
-      run: |
-        pip install GitPython pyyaml
-        python -c 'from checkout_and_collate import *; collate_files()'
+      run: pip install GitPython pyyaml && python -c collate.py
       shell: bash
+      working-directory: ${{ github.action_path }}
       env:
-        PYTHONPATH: ${{ github.action_path }}
-        GITHUB_PAGES_PUSH_PATH: ${{ github.action_path }}/${{ inputs.github_pages_directory }}
         GITHUB_PAGES_HUGO_PATH: ${{ inputs.github_pages_hugo_path }}
-        GITHUB_PAGES_PULL_BRANCH: ${{ inputs.github_pages_pull_branch }}
+        STAGING_DIR: ${{ inputs.staging_dir }}
         DEBUG: ${{ inputs.debug }}
         CONTENT: ${{ inputs.content }}
-        STAGING_DIR: ${{ inputs.staging_dir }}
     - name: "Build Hugo Site Locally"
       run: |
         docker build -t cloudposse/docs .
@@ -87,9 +110,9 @@ runs:
         HUGO_CONFIG: ${{ inputs.hugo_config }}
         HTMLTEST_CONFIG: ${{ inputs.htmltest_config }}
     - name: "Move Hugo Site Files to Publishing Directory"
-      run: cp -r ${STAGING_DIR}/${HUGO_PUBLISH_DIR} ${GITHUB_PAGES_PUSH_PATH}
+      run: cp -r ./${HUGO_PUBLISH_DIR} ${GITHUB_PAGES_PUSH_PATH}
       shell: bash
+      working-directory: ${{ inputs.staging_dir }}
       env:
-        STAGING_DIR: ${{ inputs.staging_dir }}
         HUGO_PUBLISH_DIR: ${{ inputs.hugo_publish_dir }}
-        GITHUB_PAGES_PUSH_PATH: ${{ github.action_path }}/${{ inputs.github_pages_directory }}
+        GITHUB_PAGES_PUSH_PATH: ${{ inputs.github_pages_push_path }}

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -63,7 +63,7 @@ runs:
       run: |
            pip install GitPython pyyaml
            cd $RUNNER_DIR
-           python -c 'from collate import *; collate_files()'
+           python -c 'from collate import *; collation_steps()'
            #python ${{ github.action_path }}/collate.py
       shell: bash
       env:

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -29,7 +29,7 @@ inputs:
     description: 'GitHub Actor'
     required: false
   github_pages_hugo_path:
-    description: 'location where the repo containing the Hugo files will be checked out to'
+    description: 'Location where the repo containing the Hugo files will be cloned'
     required: false
   github_pages_pull_branch:
     description: 'the branch of the repo which contains the documentation'

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -56,8 +56,7 @@ runs:
       run: |
            export CSS=${CSS:-$INPUT_CSS}
            export GITHUB_PAGES_HUGO_PATH=${GITHUB_PAGES_HUGO_PATH:-$INPUT_GITHUB_PAGES_HUGO_PATH}
-           echo -e "\n$CSS" >> ${GITHUB_PAGES_HUGO_PATH}/themes/cloudposse/src/scss/custom.scss
-           cat ${GITHUB_PAGES_HUGO_PATH}/themes/cloudposse/src/scss/custom.scss
+           echo -e "$CSS" >> ${GITHUB_PAGES_HUGO_PATH}/themes/cloudposse/src/scss/custom.scss
       shell: bash
       env:
         INPUT_CSS: ${{ inputs.CSS }}

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -106,7 +106,11 @@ runs:
       env:
         CSS: ${{ inputs.css }}
     - name: "Customize Hugo YAML Config"
-      run: yq $CONFIG config.yaml
+      run: |
+        curl -1sLf 'https://dl.cloudsmith.io/public/cloudposse/packages/setup.deb.sh' | bash
+        apt-get install yq
+        yq $CONFIG config.yaml
+        rm setup.deb.sh
       shell: bash
       working-directory: ${{ inputs.staging_dir }}
       env:

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: 'URL of the Hugo site after deployment'
     required: false
   hugo_publish_dir:
-    description: 'directory in the repo that GitHub Pages will deploy to'
+    description: 'Directory in the repo that GitHub Pages will deploy to'
     required: false
   hugo_config:
     description: 'location of to-be-written Hugo config file (actual location not important)'

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -110,7 +110,8 @@ runs:
         curl -1sLf 'https://dl.cloudsmith.io/public/cloudposse/packages/setup.deb.sh' | sudo bash
         sudo apt-get install yq
         echo "config: $CONFIG"
-        yq e -i $CONFIG config.yaml
+        yq e -i "$CONFIG" config.yaml
+        echo "catting config.yaml:"
         cat config.yaml
         rm setup.deb.sh
       shell: bash

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -36,18 +36,11 @@ runs:
            pip install GitPython pyyaml
            echo "RUNNER_DIR: ${RUNNER_DIR}" && echo "pwd: $(pwd)"
            echo "whoami: $(whoami)" && echo "groups: $(groups)"
-           cd $RUNNER_DIR
-           pwd && ls -lhatr
-           python --version
-           python -c "import os; print(f'current directory: {os.getcwd()}')"
            python -c "import sys; print(f'search path: {sys.path}'); import os; print(f'folder: {sys.path[1]}, contents: {os.listdir(sys.path[1])}'); from collate import *; checkout_repos()"
-           #python collate.py
            #python -c 'from collate import *; checkout_repos()'
-           #python ${{ github.action_path }}/collate.py
       shell: bash
       env:
         PYTHONPATH: ${{ github.action_path }}
-        RUNNER_DIR: ${{ github.action_path }}
         STAGING_DIR: /tmp/staging
         INPUT_CONTENT: ${{ inputs.CONTENT }}
         INPUT_DEBUG: ${{ inputs.DEBUG }}
@@ -67,7 +60,7 @@ runs:
            #python ${{ github.action_path }}/collate.py
       shell: bash
       env:
-        RUNNER_DIR: ${{ github.action_path }}
+        PYTHONPATH: ${{ github.action_path }}
         STAGING_DIR: /tmp/staging
         INPUT_CONTENT: ${{ inputs.CONTENT }}
         INPUT_DEBUG: ${{ inputs.DEBUG }}

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -26,7 +26,7 @@ inputs:
     description: 'GitHub token'
     required: false
   github_actor:
-    description: 'github actor'
+    description: 'GitHub Actor'
     required: false
   github_pages_hugo_path:
     description: 'location where the repo containing the Hugo files will be checked out to'

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: 'Location of to-be-written Hugo config file (actual location not important)'
     required: false
   htmltest_config:
-    description: 'location of to-be-written htmltest config file (actual location not important)'
+    description: 'Location to write the htmltest config file (actual location not important)'
     required: false
   github_token:
     description: 'github token'

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -40,7 +40,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - id: checkout-repos
+    - name: "Checkout All Repos"
       run: |
            pip install GitPython pyyaml
            python -c 'from checkout_and_collate import *; checkout_repos()'
@@ -52,7 +52,7 @@ runs:
         INPUT_GITHUB_PAGES_HUGO_PATH: ${{ inputs.GITHUB_PAGES_HUGO_PATH }}
         INPUT_DEBUG: ${{ inputs.DEBUG }}
         INPUT_STAGING_DIR: ${{ inputs.STAGING_DIR }}
-    - id: append-custom-css
+    - name: "Append Custom CSS"
       run: |
            export CSS=${CSS:-$INPUT_CSS}
            export GITHUB_PAGES_HUGO_PATH=${GITHUB_PAGES_HUGO_PATH:-$INPUT_GITHUB_PAGES_HUGO_PATH}
@@ -61,7 +61,7 @@ runs:
       env:
         INPUT_CSS: ${{ inputs.CSS }}
         INPUT_GITHUB_PAGES_HUGO_PATH: ${{ inputs.GITHUB_PAGES_HUGO_PATH }}
-    - id: collate-files
+    - name: "Collate Documentation Files"
       run: |
            pip install GitPython pyyaml
            python -c 'from checkout_and_collate import *; collate_files()'
@@ -74,7 +74,7 @@ runs:
         INPUT_DEBUG: ${{ inputs.DEBUG }}
         INPUT_CONTENT: ${{ inputs.CONTENT }}
         INPUT_STAGING_DIR: ${{ inputs.STAGING_DIR }}
-    - id: build-hugo
+    - name: "Build Hugo Site Locally"
       run: |
            # These variables need to be defined manually when GitHub Actions variables are passed in using
            # with: instead of env: in order for the next steps to work.
@@ -94,7 +94,7 @@ runs:
         INPUT_HUGO_PUBLISH_DIR: ${{ inputs.HUGO_PUBLISH_DIR }}
         INPUT_HUGO_CONFIG: ${{ inputs.HUGO_CONFIG }}
         INPUT_HTMLTEST_CONFIG: ${{ inputs.HTMLTEST_CONFIG }}
-    - id: publish-site
+    - name: "Move Hugo Site Files to Publishing Directory"
       run: |
            export STAGING_DIR=${STAGING_DIR:-$INPUT_STAGING_DIR}
            export HUGO_PUBLISH_DIR=${HUGO_PUBLISH_DIR:-$INPUT_HUGO_PUBLISH_DIR}

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -85,6 +85,7 @@ runs:
            export STAGING_DIR=${STAGING_DIR:-$INPUT_STAGING_DIR}
            cd $STAGING_DIR
            docker build -t cloudposse/docs .
+           make lint
            make release
            make real-clean hugo/build
       shell: bash

--- a/actions/publish-github-pages/action.yml
+++ b/actions/publish-github-pages/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: 'comma-separated list of directories in the top level of the repo that contains documentation'
     required: false
   css:
-    description: 'custom CSS to insert into custom.scss'
+    description: 'Custom CSS to customize the look and feel'
     required: false
   debug:
     description: 'whether to turn on debug printouts/functionality'

--- a/actions/publish-github-pages/checkout_and_collate.py
+++ b/actions/publish-github-pages/checkout_and_collate.py
@@ -104,9 +104,8 @@ def collate_files():
     collate_docs_files()
 
 def stage_hugo_build_files():
-    # This function assumes that the repo pointed to by HUGO_REPO has a structure that is similar
-    # to https://github.com/cloudposse/docs. If that is not the case, some of the below copy
-    # commands may fail.
+    # This function assumes that the repo (HUGO_REPO) has a structure that is similar
+    # to https://github.com/cloudposse/docs. If that is not the case, some of the commands below may fail.
     os.mkdir(STAGING_DIR)
     copy_dirs = ["tasks", "themes", "static", "layouts", "content"]
     for copy_dir in copy_dirs:

--- a/actions/publish-github-pages/checkout_and_collate.py
+++ b/actions/publish-github-pages/checkout_and_collate.py
@@ -49,6 +49,7 @@ def read_in_env_vars(calling_func):
                        ("GITHUB_PAGES_PUSH_BRANCH", None, False),
                        ("HUGO_REPO", "https://github.com/cloudposse/docs", False),
                        ("GITHUB_PAGES_PUSH_PATH", None, True),
+                       ("GITHUB_PAGES_HUGO_PATH", "/tmp/hugo/", True),
                        ("DEBUG", None, False)]
     elif calling_func == "collate_files":
         global_vars = [("GITHUB_PAGES_DIRECTORY", None, True),

--- a/actions/publish-github-pages/checkout_and_collate.py
+++ b/actions/publish-github-pages/checkout_and_collate.py
@@ -10,6 +10,7 @@
 # CONTENT - comma-separated list of directories in the top level of the repo that contains documentation
 # HUGO_REPO - Cloud Posse repository containing Hugo scaffolding
 # STAGING_DIR - directory to collate all docs and Hugo files in
+# GITHUB_PAGES_HUGO_PATH - location where the repo containing the Hugo files will be checked out to
 #
 # Example parameter values:
 # GITHUB_PAGES_DIRECTORY=github_pages
@@ -19,6 +20,7 @@
 # CONTENT=docs,content
 # HUGO_REPO=https://github.com/cloudposse/docs
 # STAGING_DIR=/tmp/staging
+# GITHUB_PAGES_HUGO_PATH=/tmp/hugo
 
 import os
 import re

--- a/actions/publish-github-pages/checkout_and_collate.py
+++ b/actions/publish-github-pages/checkout_and_collate.py
@@ -48,6 +48,7 @@ def read_in_env_vars(calling_func):
                        ("GITHUB_PAGES_PULL_BRANCH", None, False),
                        ("GITHUB_PAGES_PUSH_BRANCH", None, False),
                        ("HUGO_REPO", "https://github.com/cloudposse/docs", False),
+                       ("GITHUB_PAGES_PULL_PATH", "/tmp/pull/", True),
                        ("GITHUB_PAGES_PUSH_PATH", None, True),
                        ("GITHUB_PAGES_HUGO_PATH", "/tmp/hugo/", True),
                        ("DEBUG", None, False)]
@@ -58,7 +59,6 @@ def read_in_env_vars(calling_func):
                        ("GITHUB_PAGES_PUSH_BRANCH", None, False),
                        ("CONTENT", None, False),
                        ("HUGO_REPO", "https://github.com/cloudposse/docs", False),
-                       ("GITHUB_PAGES_PULL_PATH", "/tmp/pull/", True),
                        ("GITHUB_PAGES_HUGO_PATH", "/tmp/hugo/", True),
                        ("STAGING_DIR", "/tmp/staging", True),
                        ("GITHUB_PAGES_PUSH_PATH", None, True),

--- a/actions/publish-github-pages/checkout_and_collate.py
+++ b/actions/publish-github-pages/checkout_and_collate.py
@@ -59,6 +59,7 @@ def read_in_env_vars(calling_func):
                        ("GITHUB_PAGES_PUSH_BRANCH", None, False),
                        ("CONTENT", None, False),
                        ("HUGO_REPO", "https://github.com/cloudposse/docs", False),
+                       ("GITHUB_PAGES_PULL_PATH", "/tmp/pull/", True),
                        ("GITHUB_PAGES_HUGO_PATH", "/tmp/hugo/", True),
                        ("STAGING_DIR", "/tmp/staging", True),
                        ("GITHUB_PAGES_PUSH_PATH", None, True),

--- a/actions/publish-github-pages/collate.py
+++ b/actions/publish-github-pages/collate.py
@@ -80,7 +80,7 @@ def prune_hugo_content_files():
     print(f"content_subfolders: {content_subfolders}")
     for content_subfolder in content_subfolders:
         if content_subfolder not in hugo_content_folders:
-            shutil.rmtree( os.path.join(content_path, content_subfolder) )
+            rmtree( os.path.join(content_path, content_subfolder) )
 
 def collate_docs_files():
     content_folders = CONTENT.split(",")

--- a/actions/publish-github-pages/collate.py
+++ b/actions/publish-github-pages/collate.py
@@ -81,6 +81,8 @@ def prune_hugo_content_files():
     for content_subfolder in content_subfolders:
         if content_subfolder not in hugo_content_folders:
             rmtree( os.path.join(content_path, content_subfolder) )
+    content_subfolders = [f.path.replace(content_path + "/", "") for f in os.scandir(content_path) if f.is_dir()]
+    print(f"content_subfolders: {content_subfolders}")
 
 def collate_docs_files():
     content_folders = CONTENT.split(",")

--- a/actions/publish-github-pages/collate.py
+++ b/actions/publish-github-pages/collate.py
@@ -74,15 +74,22 @@ def stage_hugo_files():
         copy2( os.path.join(GITHUB_PAGES_HUGO_PATH, copy_file), STAGING_DIR )
 
 def prune_hugo_content_files():
+    # Put the directory names we want to keep into a list.
     hugo_content_folders = HUGO_CONTENT.split(",")
+
+    # If we're keeping and documentation at all, there are two utility subdirectories that we'll
+    # need to keep, too.
+    if hugo_content_folders:
+        hugo_content_folders.append("documentation")
+        hugo_content_folders.append("glossary")
+
+    # Compare the list of subdirectories we have against the list we want to keep and remove any
+    # any that aren't in the list.
     content_path = os.path.join(STAGING_DIR, "content")
     content_subfolders = [f.path.replace(content_path + "/", "") for f in os.scandir(content_path) if f.is_dir()]
-    print(f"content_subfolders: {content_subfolders}")
     for content_subfolder in content_subfolders:
         if content_subfolder not in hugo_content_folders:
             rmtree( os.path.join(content_path, content_subfolder) )
-    content_subfolders = [f.path.replace(content_path + "/", "") for f in os.scandir(content_path) if f.is_dir()]
-    print(f"content_subfolders: {content_subfolders}")
 
 def collate_docs_files():
     content_folders = CONTENT.split(",")

--- a/actions/publish-github-pages/collate.py
+++ b/actions/publish-github-pages/collate.py
@@ -77,7 +77,7 @@ def prune_hugo_content_files():
     # Put the directory names we want to keep into a list.
     hugo_content_folders = HUGO_CONTENT.split(",")
 
-    # If we're keeping and documentation at all, there are two utility subdirectories that we'll
+    # If we're keeping and documentation at all, there are three utility subdirectories that we'll
     # need to keep, too.
     if hugo_content_folders:
         hugo_content_folders.append("documentation")

--- a/actions/publish-github-pages/collate.py
+++ b/actions/publish-github-pages/collate.py
@@ -27,7 +27,7 @@ def main():
 
     # Create a separate build folder, STAGING_DIR, and populate it with the essential Hugo build
     # files.
-    stage_hugo_build_files()
+    stage_hugo_files()
 
     # Remove any generic content that comes with the Hugo repo, unless it's explicitly marked for
     # keeping.

--- a/actions/publish-github-pages/collate.py
+++ b/actions/publish-github-pages/collate.py
@@ -82,6 +82,7 @@ def prune_hugo_content_files():
     if hugo_content_folders:
         hugo_content_folders.append("documentation")
         hugo_content_folders.append("glossary")
+        hugo_content_folders.append("community")
 
     # Compare the list of subdirectories we have against the list we want to keep and remove any
     # any that aren't in the list.


### PR DESCRIPTION
## what
* Rewriting the `publish-github-pages` GitHub Action in Python.

## why
* This action is already pretty complex, and there's still more functionality to add. Having it be easily debuggable could save a lot of time.

## references
* https://cloudposse.atlassian.net/browse/CPCO-467