### PR TITLE
adding 'AWS_EC2_METADATA_DISABLED: true' to hugo.yaml file to address issues with github actions on ubuntu-latest

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -21,6 +21,7 @@ env:
   CACHE_LOCATION: ./.htmltest/refcache.json
   DOCKER_RUN_FLAGS: "--rm"
   HUGO_URL: https://docs.cloudposse.com/
+  AWS_EC2_METADATA_DISABLED: true
 
 jobs:
   hugo-build:


### PR DESCRIPTION
## what
* Adding the `AWS_EC2_METADATA_DISABLED=true` flag to the `hugo.yaml` GitHub Action.

## why
* `hugo.yaml` was previously throwing an error when we tried to push a release to S3. This should fix it.

## references
* https://github.com/cloudposse/docs/runs/2189730724?check_suite_focus=true
* https://github.com/aws/aws-cli/issues/5623#issuecomment-801240811
* https://github.com/actions/virtual-environments/issues/1816