### PR TITLE
Fixed vertical align

### DIFF
--- a/themes/cloudposse/src/scss/custom.scss
+++ b/themes/cloudposse/src/scss/custom.scss
@@ -30,6 +30,7 @@ code {
   border-radius: 3px;
   background-color: #ffffff7a;
   font-family: Consolas,andale mono wt,andale mono,lucida console,lucida sans typewriter,dejavu sans mono,bitstream vera sans mono,liberation mono,nimbus mono l,Monaco,courier new,Courier,monospace;
+  vertical-align: inherit;
 }
 
 pre code {


### PR DESCRIPTION
## what
* Changed `vertical-align` to inherit defaults

## why
* Code blocks were not aligned with the rest of the text, which was ugly

