### PR TITLE
feat: updates atmos tutorial to use cloudposse/tutorials > one off image

### DIFF
--- a/content/tutorials/first-aws-environment.md
+++ b/content/tutorials/first-aws-environment.md
@@ -29,7 +29,7 @@ Prior to starting this tutorial, you should be sure that you understand [our var
 
 ### 1. Clone the tutorials repository + Run the `tutorials` image
 
-As part of this tutorial (and others in our tutorial series), we'll be utilizing [our tutorials repository](https://github.com/cloudposse/tutorials). This repository includes code and relevant materials for you to use alongside this tutorial walk through.
+As part of this tutorial (and others following in our tutorial series), we'll be utilizing [our tutorials repository](https://github.com/cloudposse/tutorials). This repository includes code and relevant materials for you to use alongside this tutorial walk through.
 
 Let's clone it to your local machine and `cd` into it:
 
@@ -39,22 +39,19 @@ git clone git@github.com:cloudposse/tutorials.git
 cd tutorials
 ```
 
-Now that we've got our code, we're going to want to interact with it using our standard set of tools. Following the SweetOps methodology, we're going to do so using a docker toolbox, which is a Docker image built on top of Geodesic. This entire `tutorials` repository is actually Dockerized to make that part easy, so let's build and run our `cloudposse/tutorials` image:
+Now that we've got our code, we're going to want to interact with it using our standard set of tools. Following the SweetOps methodology, we're going to do so using a docker toolbox, which is a Docker image built on top of Geodesic. This entire `tutorials` repository is actually Dockerized to make that part easy, so let's run our `cloudposse/tutorials` image:
 
 ```bash
-# Pull our build-harness
-make init
-
-# Build our docker image
-# Geodesic is the base image for our tutorials image and it isn't tiny by any means
-# Go grab a coffee while you wait ☕️
-make build
-
 # Run our docker image
-make run
+docker run -it \
+          --rm \
+          --volume "$HOME":/localhost \
+          --volume "$PWD":/tutorials \
+          --name sweetops-tutorials \
+          cloudposse/tutorials:latest;
 ```
 
-This will build the `tutorials` image locally on your machine and then runs it while also mounting the various tutorial folders so you can edit them on your host machine or in the container and the changes will propogate either direction.
+This will pull the `tutorials` image to your local machine, run a new container from that image, and mount the various tutorial folders so you can edit them on your host machine or in the container and the changes will propogate either direction.
 
 ![Tutorial Shell](/assets/tutorials-3-tutorials-shell.png)
 
@@ -68,7 +65,7 @@ aws-vault exec $YOUR_PROFILE -- bash --login
 cd /tutorials/03-first-aws-environment
 ```
 
-This `03-first-aws-environment/` directory that you're now in should be looking a little bit familiar from our first tutorial:
+This `03-first-aws-environment/` directory that you're now in should be looking a little bit familiar from our `atmos` tutorial:
 
 * We've got a `components/` directory which holds terraform components that we're looking to `apply` to our AWS Account.
 * We've got a `stacks/` directory which holds the declarative descriptions of 3 environments:

--- a/content/tutorials/geodesic-getting-started.md
+++ b/content/tutorials/geodesic-getting-started.md
@@ -8,7 +8,7 @@ weight: 1
 
 In the landscape of developing infrastructure, there are dozens of tools that we all need on our personal machines to do our jobs. In SweetOps, instead of having you install each tool individually, we use Docker to package all of these tools into one convenient image that you can use as your infrastructure automation toolbox. We call it [Geodesic]({{< relref "reference/tools.md#geodesic" >}}) and we use it as our DevOps automation shell and as the base Docker image for all of our DevOps scripting / CI jobs.
 
-In this tutorial, we'll walk you through how to use Geodesic to execute Terraform and other tooling. We'll be sure to talk about what is going on under the hood to ensure you're fully getting the picture.
+In this tutorial, we'll walk you through how to use Geodesic to execute Terraform and other tooling. We'll be sure to talk about what is going on under the hood to ensure you're getting the full picture.
 
 ## Prerequisites
 
@@ -54,7 +54,7 @@ There are a few things going on there, so let's break that down a bit:
 1. We're using the `--volume` flag to mount our `$HOME` directory to `/localhost` in our new container. This is a Geodesic standard practice which enables the container and your corresponding shell session to have access to your dotfiles, configurations, and the projects that you'll work on.
    1. **NOTE**: If you're running on Linux and using Geodesic, any files written to the `--volume` mounts will be owned by the user inside the container, which is `root`. [See here for potential workarounds](https://github.com/moby/moby/issues/3124#issuecomment-104936573).
 1. Finally, after the image name, we're passing `--login`. This is the Docker `CMD` that we're passing to our image. Since we override the Docker `ENTRYPOINT` with a small bash script, our `--login` `CMD` results in calling `/bin/bash --login` which creates a new [bash login shell](https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html).
-   1. It's worth noting that since Geodesic `v0.143.2` ([PR #693](https://github.com/cloudposse/geodesic/pull/693)), you can now drop `--login` as default `CMD` will provide the same functionality.
+   1. It's worth noting that since Geodesic `v0.143.2` ([PR #693](https://github.com/cloudposse/geodesic/pull/693)), you can now drop `--login` as the default `CMD` will provide the same functionality.
 
 The result of running this command should look like this:
 


### PR DESCRIPTION
## what
* Updates our `atmos-getting-started.md` tutorial to use `cloudposse/tutorials` image
* Various other small wording fixes

## why
* Avoids a one-off image for the atmos tutorial and helps speed things up since the tutorial follower will no longer need to build the image locally. 
* Addresses some off wording + cleans things up to be more consistent

## references
* Linked work to publish `cloudposse/tutorials` image: https://github.com/cloudposse/tutorials/pull/7
