### PR TITLE
git.io->cloudposse.tools update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endif
 
 export COMPONENTS_DIR ?= static/components
 
--include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+-include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)
 -include tasks/Makefile.*
 
 ## Install OSX deps

--- a/content/reference/tools.md
+++ b/content/reference/tools.md
@@ -226,7 +226,7 @@ It's 100% Open Source and licensed under [APACHE2]({{< relref "LICENSE.md" >}}).
 At the top of your `Makefile` add, the following...
 
 ```shell
--include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+-include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)
 ```
 
 This will download a `Makefile` called `.build-harness` and include it at run-time. We recommend adding the `.build-harness` file to your `.gitignore`.


### PR DESCRIPTION
## what and why 
Change all references to `git.io/build-harness` into `cloudposse.tools/build-harness`, since `git.io` redirects will stop working on April 29th, 2022.

## References
- DEV-143