### PR TITLE
Linked top GitHub button to component subfolder

### DIFF
--- a/src/components/github-buttons/github-buttons.js
+++ b/src/components/github-buttons/github-buttons.js
@@ -15,7 +15,7 @@ export default function GitHubButtons({custom_edit_url}) {
         <ul>
           <li>
             <GitHubButton
-              href={'https://github.com/' + repoFullName}
+              href={custom_edit_url}
               aria-label="Open GitHub">GitHub</GitHubButton>
           </li>
 

--- a/src/components/github-buttons/github-buttons.js
+++ b/src/components/github-buttons/github-buttons.js
@@ -5,17 +5,21 @@ export default function GitHubButtons({custom_edit_url}) {
   if (custom_edit_url == undefined) {
     return (<div/>);
   } else {
-    const url = new URL(custom_edit_url);
-    const parts = url.pathname.split('/');
+    const url = new URL(custom_edit_url.replace('/blob/', '/tree/'));
 
-    let repoFullName = parts[1] + '/' + parts[2];
+    let parts = url.pathname.split('/');
+    parts.shift();
+    let repoFullName = parts[0] + '/' + parts[1];
+
+    parts.pop();
+    const componentFolderPath = parts.join('/');
 
     return (
       <div className="github_buttons">
         <ul>
           <li>
             <GitHubButton
-              href={custom_edit_url}
+              href={'https://github.com/' + componentFolderPath}
               aria-label="Open GitHub">GitHub</GitHubButton>
           </li>
 


### PR DESCRIPTION
## what
* Linked top github button directly to component subfolder

## why
* UX improvements

## references
