### PR TITLE
chore: add rego support for spacelift policies

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -294,7 +294,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
-        additionalLanguages: ['hcl', 'bash'],
+        additionalLanguages: ['hcl', 'bash', 'rego'],
       },
     }),
 };


### PR DESCRIPTION
## what
* enable rego for prism

## why
* code blocks for spacelift policies will be in rego
