### PR TITLE
`.editorconfig` Typo

### DIFF
--- a/content/docs/reference/best-practices/terraform-best-practices.md
+++ b/content/docs/reference/best-practices/terraform-best-practices.md
@@ -94,7 +94,7 @@ indent_style = tab
 indent_size = 4
 
 [*.yaml]
-intent_style = space
+indent_style = space
 indent_size = 2
 
 [*.sh]


### PR DESCRIPTION
## what
fixed intent typo

## why
should be spelled "indent"

## references
https://cloudposse.slack.com/archives/C01EY65H1PA/p1685638634845009

