### PR TITLE
Update make-best-practices.md

### DIFF
--- a/content/docs/reference/best-practices/make-best-practices.md
+++ b/content/docs/reference/best-practices/make-best-practices.md
@@ -121,7 +121,7 @@ Simply add this code snippet to your `Makefile` and you'll get this functionalit
 ## This help screen
 help:
         @printf "Available targets:\n\n"
-        @awk '/^[a-zA-Z\-\_0-9%:\\]+/ { \
+        @awk '/^[a-zA-Z\-_0-9%:\\]+/ { \
           helpMessage = match(lastLine, /^## (.*)/); \
           if (helpMessage) { \
             helpCommand = $$1; \


### PR DESCRIPTION
Underscore should not be escaped with a backslash

## what
Remove escaping of underscore in the awk regex

## why
`\_` is not a valid GNU awk regular expression, at least not in GNU Awk 5.1.0 \
which warns
  awk: cmd. line:1: warning: regexp escape sequence `\_' is not a known regexp operator