### PR TITLE
bugfix: image-zoom incorrect selector

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -320,7 +320,7 @@ const config = {
         additionalLanguages: ['hcl', 'bash', 'rego'],
       },
       zoom: {
-        selector: '.markdown :not(em) > img',
+        selector: '.markdown > img',
         config: {
           // options you can specify via https://github.com/francoischalifour/medium-zoom#usage
           background: {


### PR DESCRIPTION
## what
* Fixes selector to apply to all images in markdown divs, this applies to all sites

## why
* Allows image zoom on all images

