### PR TITLE
Warn about input errors with object inputs, remove DNS section

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,8 @@ indent_size = 4
 
 [*.sh]
 indent_style = tab
+
+[*.py]
+indent_style = space
+indent_size = 4
+

--- a/content/docs/fundamentals/introduction.md
+++ b/content/docs/fundamentals/introduction.md
@@ -34,7 +34,7 @@ How does it differentiate from these solutions?
 
 1. It's 100% Open Source: SweetOps [is on GitHub](https://github.com/cloudposse) and is free to use with no strings attached under Apache 2.0.
 1. It's comprehensive: SweetOps is not only about Terraform. It provides patterns and conventions for building cloud native platforms that are security focused, Kubernetes-based, and driven by continuous delivery.
-1. It's community focused: SweetOps has [over 3400 users in Slack](https://sweetops.com/slack/), well-attended weekly office hours, and a [budding community forum](https://ask.sweetops.com/).
+1. It's community focused: SweetOps has [over 9000 users in Slack](https://sweetops.com/slack/), well-attended weekly office hours, and a [budding community forum](https://ask.sweetops.com/).
 
 
 ## How is this documentation structured?

--- a/content/docs/intro.md
+++ b/content/docs/intro.md
@@ -12,7 +12,7 @@ Start with getting familiar with the [geodesic](/reference/tools.mdx#geodesic).
 
 Get intimately familiar with docker inheritance and [multi-stage docker builds](/reference/best-practices/docker-best-practices.md#multi-stage-builds). We use this pattern extensively.
 
-Check out our [terraform-aws-components](https://github.com/cloudposse/terraform-aws-components) for reference architectures to easily provision infrastructure
+Check out our [terraform-aws-components](https://github.com/cloudposse/terraform-aws-components) for reference architectures to easily provision infrastructure.
 
 ## Tools
 
@@ -70,7 +70,7 @@ Review our [glossary](/category/glossary/) if there are any terms that are confu
 
 File issues anywhere you find the documentation lacking by going to our [docs repo](https://github.com/cloudposse/docs).
 
-Join our [Slack Community](https://cloudposse.com/slack/) and speak directly with the maintainers
+Join our [Slack Community](https://cloudposse.com/slack/) and speak directly with the maintainers.
 
 We provide "white glove" DevOps support. [Get in touch](/contact-us.md) with us today!
 

--- a/content/docs/reference/best-practices/docker-best-practices.md
+++ b/content/docs/reference/best-practices/docker-best-practices.md
@@ -15,10 +15,10 @@ Try to leverage the same base image in as many of your images as possible for fa
 
 ## Multi-stage Builds
 
-There are two ways to leverage multi-stage builds.
+There are two ways to leverage multi-stage builds:
 
-1. *Build-time Environments* The most common application of multi-stage builds is for using a build-time environment for compiling apps, and then a minimal image (E.g. `alpine` or `scratch`) for distributing the resultant artifacts (e.g. statically-linked go binaries).
-2. *Multiple-Inheritance* We like to think of "multi-stage builds" as a mechanism for "multiple inheritance" as it relates to docker images. While not technically the same thing, using mult-stage images, it's possible `COPY --from=other-image` to keep things very DRY.
+1. *Build-time Environments* The most common application of multi-stage builds is for using a build-time environment for compiling apps, and then a minimal image (E.g. `alpine` or `scratch`) for distributing the resultant artifacts (e.g. statically-linked `go` binaries).
+2. *Multiple-Inheritance* We like to think of "multi-stage builds" as a mechanism for "multiple inheritance" as it relates to docker images. While not technically the same thing, using multi-stage images makes it possible to `COPY --from=other-image` to keep things very DRY.
 
 :::info
 - <https://docs.docker.com/develop/develop-images/multistage-build/>

--- a/content/docs/reference/best-practices/terraform-best-practices.md
+++ b/content/docs/reference/best-practices/terraform-best-practices.md
@@ -100,6 +100,23 @@ conversion errors, and allows for future expansion without breaking changes.
 Make as many fields as possible optional, provide defaults at every level of
 nesting, and use `nullable = false` if possible.
 
+:::caution Extra (or Misspelled) Fields in Object Inputs Will Be Silently Ignored
+
+If you use an object with defaults as an input, Terraform will not give any
+indication if the user provides extra fields in the input object. This is
+particularly a problem if they misspelled an optional field name, because
+the misspelled field will be silently ignored, and the default value the
+user intended to override will silently be used. This is
+[a limitation of Terraform](https://github.com/hashicorp/terraform/issues/29204#issuecomment-1989579801).
+Furthermore, there is no way to add any checks for this situation, because
+the input will have already been transformed (unexpected fields removed) by
+the time any validation code runs. This makes using an object a trade-off
+versus using separate inputs, which do not have this problem, or `type = any`
+which allows you to write validation code to catch this problem and
+additional code to supply defaults for missing fields.
+
+:::
+
 Reserve `type = any` for exceptional cases where the input is highly
 variable and/or complex, and the module is designed to handle it. For
 example, the configuration of a [Datadog synthetic test](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/synthetics_test)
@@ -117,8 +134,9 @@ often use a large number of input variables of simple types. This is because
 in the early development of Terraform, there was no good way to define
 complex objects with defaults. However, now that Terraform supports complex
 objects with field-level defaults, we recommend using a single object input
-variable with such defaults to group related configuration. This makes the
-interface easier to understand and use.
+variable with such defaults to group related configuration, taking into consideration
+the trade-offs listed in the [above caution](#use-objects-with-optional-fields-for-complex-inputs).
+This makes the interface easier to understand and use.
 
 For example, prefer:
 
@@ -152,21 +170,8 @@ variable "eip_delete_timeout" {
 ```
 
 However, using an object with defaults versus multiple simple inputs is not
-without tradeoffs.
+without trade-offs, as explained in the [above caution](#use-objects-with-optional-fields-for-complex-inputs).
 
-:::caution Extra (or Misspelled) Fields in the Input Will Be Silently Ignored
-
-If you use an object with defaults as an input, Terraform will not give any
-indication if the user provides extra fields in the object. This is
-particularly a problem if they misspelled an optional field name, because
-the misspelled field will be silently ignored, and the default value the
-user intended to override will silently be used. This is
-[a limitation of Terraform](https://github.com/hashicorp/terraform/issues/29204#issuecomment-1989579801).
-Furthermore, there is no way to add any checks for this situation, because
-the input will have already been transformed (unexpected fields removed) by
-the time any validation code runs.
-
-:::
 
 There are a few ways to mitigate this problem besides using separate inputs:
 

--- a/content/docs/reference/terraform-in-depth/terraform-count-vs-for-each.md
+++ b/content/docs/reference/terraform-in-depth/terraform-count-vs-for-each.md
@@ -402,7 +402,7 @@ better because it is simpler and all of the issues with `count` are already
 understood.
 
 ::: note
-Another limitation, thought not frequently encountered, is that "sensitive"
+Another limitation, though not frequently encountered, is that "sensitive"
 values, such as sensitive input variables, sensitive outputs, or sensitive
 resource attributes, cannot be used as arguments to `for_each`. As stated
 previously, the value supplied to `for_each` is used as part of the resource

--- a/content/docs/reference/terraform-in-depth/terraform-count-vs-for-each.md
+++ b/content/docs/reference/terraform-in-depth/terraform-count-vs-for-each.md
@@ -303,7 +303,7 @@ If you are unlucky (or if you run `terraform apply` 3 times), the change
 will go through, and user "Dick" will be renamed user "Tom", meaning that
 whatever access Dick had, Tom now gets. Likewise, user Dick is renamed Harry,
 getting Harry's access, and Harry get the newly created user. For example, Tom
-can now log in with user name Tom using Dick's password, while Harry will be
+can now log in with user name "Tom" using Dick's password, while Harry will be
 locked out as a new user. This nightmare scenario has a lot to do with
 peculiarities of the implementation of IAM principals, but gives you an idea
 of what can happen when you use `count` with a list of resource configurations.
@@ -321,6 +321,8 @@ added to or deleted from the list, or when the list provided in a random order
 affected. The answer to this is `for_each`, but that is not without its own
 limitations.
 :::
+
+### For Each is Stable, But Not Always Feasible to Use
 
 #### The Stability of `for_each`
 
@@ -398,6 +400,16 @@ In other cases, such as when the configurations vary, using proxy keys like
 this has all the same problems as `count`, in which case using `count` is
 better because it is simpler and all of the issues with `count` are already
 understood.
+
+::: note
+Another limitation, thought not frequently encountered, is that "sensitive"
+values, such as sensitive input variables, sensitive outputs, or sensitive
+resource attributes, cannot be used as arguments to `for_each`. As stated
+previously, the value supplied to `for_each` is used as part of the resource
+address, and as such, it will always be disclosed in UI output, which is why
+sensitive values are not allowed. Attempts to use sensitive values as
+`for_each` arguments will result in an error.
+:::
 
 Ideally, as we saw with IAM users in the examples above, the user would
 supply static keys in the initial configuration, and then they would always

--- a/content/docs/tutorials/geodesic-getting-started.md
+++ b/content/docs/tutorials/geodesic-getting-started.md
@@ -27,9 +27,9 @@ Before we jump in, it's important to note that Geodesic is built around some adv
 
 Let's talk about a few of the ways that one can run Geodesic. Our toolbox has been built to satisfy many use-cases, and each result in a different pattern of invocation:
 
-1. You can **run standalone** Geodesic as a standard docker container using `docker run`. This enables you to get started quickly, to avoid fiddling with configuration or run one-off commands using some of the built-in tools.
+1. You can **run standalone** Geodesic as a standard docker container using `docker run`. This enables you to quickly use most of the built-in tools. (Some tools require installing the wrapper script first, as explained in the next step.)
    1. Example: `docker run -it --rm --volume $HOME:/localhost cloudposse/geodesic:latest-debian --login` opens a bash login shell (`--login` is our Docker `CMD` here; it's actually just [the arguments passed to the `bash` shell](https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html) which is our `ENTRYPOINT`) in our Geodesic container.
-   1. Example: `docker run -it --rm --volume $HOME:/localhost cloudposse/geodesic:latest-debian -c "terraform version"` executes the `terraform version` command as a one off and outputs the result.
+   1. Example: `docker run --rm cloudposse/geodesic:latest-debian -c "terraform version"` executes the `terraform version` command as a one-off and outputs the result.
 1. You can **install** Geodesic onto your local machine using what we call the docker-bash pattern (e.g. `docker run ... | bash`). Similar to above, this enables a quickstart process but supports longer lived usage as it creates a callable script on your machine that enables reuse any time you want to start a shell.
    1. Example: `docker run --rm cloudposse/geodesic:latest-debian init | bash -s latest-debian` installs `/usr/local/bin/geodesic` on your local machine which you can execute repeatedly via simply typing `geodesic`. In this example, we're pinning the script to use the `cloudposse/geodesic:latest-debian` docker image, but we could also pin to our own image or to a specific version.
 1. Lastly, you can **build your own toolbox** on top of Geodesic. This is what SweetOps generally recommends to practitioners. We do this when we want to provide additional packages or customization to our team while building on the foundation that geodesic provides. This is simple to do by using Geodesic as your base image (e.g. `FROM cloudposse/geodesic:latest-debian`) in your own `Dockerfile`, adding your own Docker `RUN` commands or overriding environment variables, and then using `docker build` to create a new image that you distribute to your team. This is more advanced usage and we'll cover how to do this in a future how-to article.
@@ -90,9 +90,9 @@ terraform init
 terraform apply -auto-approve
 ```
 
-Sweet, you should see a successful `terraform apply` with some detailed `output` info on the original star wars hero! 😎
+Sweet, you should see a successful `terraform apply` with some detailed `output` data on the original star wars hero! 😎
 
-Just to show some simple usage of another tool in the toolbox, how about we pull apart that info and get that hero's name?
+Just to show some simple usage of another tool in the toolbox, how about we parse that data and get that hero's name?
 
 ### 4. Read some data from our Outputs
 

--- a/scripts/docs-collator/AbstractFetcher.py
+++ b/scripts/docs-collator/AbstractFetcher.py
@@ -19,8 +19,8 @@ class AbstractFetcher:
     def _fetch_readme_yaml(self, repo, module_download_dir):
         self.github_provider.fetch_file(repo, README_YAML, module_download_dir)
 
-    def _fetch_docs(self, repo, module_download_dir):
-        remote_files = self.github_provider.list_repo_dir(repo, DOCS_DIR)
+    def _fetch_docs(self, repo, module_download_dir, submodule_dir=""):
+        remote_files = self.github_provider.list_repo_dir(repo, os.path.join(submodule_dir, DOCS_DIR))
 
         for remote_file in remote_files:
             if os.path.basename(remote_file) == TARGETS_MD:  # skip targets.md

--- a/scripts/docs-collator/AbstractRenderer.py
+++ b/scripts/docs-collator/AbstractRenderer.py
@@ -15,20 +15,23 @@ class TerraformDocsRenderingError(Exception):
 
 
 class AbstractRenderer:
-    def _pre_rendering_fixes(self, repo, module_download_dir):
-        readme_yaml_file = os.path.join(module_download_dir, README_YAML)
+    def _pre_rendering_fixes(self, repo, module_download_dir, submodule_dir=""):
+        readme_yaml_file = os.path.join(module_download_dir, submodule_dir, README_YAML)
         content = io.read_file_to_string(readme_yaml_file)
         content = rendering.remove_targets_md(content)
-        content = rendering.rename_name(repo, content)
+        if submodule_dir == "":
+            content = rendering.rename_name(repo.name, content)
+        else:
+            content = rendering.rename_name("pre-fix-" + os.path.basename(submodule_dir), content)
         io.save_string_to_file(readme_yaml_file, content)
 
-    def _post_rendering_fixes(self, repo, readme_md_file):
+    def _post_rendering_fixes(self, repo, readme_md_file, submodule_dir=""):
         content = io.read_file_to_string(readme_md_file)
         content = rendering.fix_self_non_closing_br_tags(content)
         content = rendering.fix_custom_non_self_closing_tags_in_pre(content)
-        content = rendering.fix_github_edit_url(content, repo)
-        content = rendering.fix_sidebar_label(content, repo)
-        content = rendering.replace_relative_links_with_github_links(repo, content)
+        content = rendering.fix_github_edit_url(content, repo, submodule_dir)
+        content = rendering.fix_sidebar_label(content, repo, os.path.basename(submodule_dir))
+        content = rendering.replace_relative_links_with_github_links(repo, content, submodule_dir)
         io.save_string_to_file(readme_md_file, content)
 
     def _copy_extra_resources_for_docs(self, module_download_dir, module_docs_dir):

--- a/scripts/docs-collator/ModuleFetcher.py
+++ b/scripts/docs-collator/ModuleFetcher.py
@@ -40,9 +40,18 @@ class ModuleFetcher(AbstractFetcher):
 
     def __fetch_submodules(self, repo, module_download_dir):
         remote_files = self.github_provider.list_repo_dir(repo, SUBMODULES_DIR)
+        readme_files = {}
 
         for remote_file in remote_files:
-            if os.path.basename(remote_file) != README_MD:
-                continue
+            base_name = os.path.basename(remote_file)
+            dir_name = os.path.dirname(remote_file)
 
-            self.github_provider.fetch_file(repo, remote_file, module_download_dir)
+            if base_name == README_YAML:
+                readme_files[dir_name] = remote_file
+            elif base_name == README_MD and dir_name not in readme_files:
+                readme_files[dir_name] = remote_file
+
+        for readme_file in readme_files.values():
+            self.github_provider.fetch_file(repo, readme_file, module_download_dir)
+            if os.path.basename(readme_file) == README_YAML:
+                self._fetch_docs(repo, module_download_dir, submodule_dir=os.path.dirname(readme_file))

--- a/scripts/docs-collator/utils/rendering.py
+++ b/scripts/docs-collator/utils/rendering.py
@@ -64,13 +64,16 @@ def shift_headings(content):
     return '\n'.join(fixed_lines)
 
 
-def fix_sidebar_label(content, repo):
-    provider, module_name = parse_terraform_repo_name(repo.name)
+def fix_sidebar_label(content, repo, submodule_name=""):
+    module_name = submodule_name
+    if not module_name:
+        provider, module_name = parse_terraform_repo_name(repo.name)
     return SIDEBAR_LABEL_REGEX.sub(f'sidebar_label: {module_name}', content)
 
 
-def fix_github_edit_url(content, repo):
-    github_edit_url = f"custom_edit_url: https://github.com/{repo.full_name}/blob/{repo.default_branch}/README.yaml"
+def fix_github_edit_url(content, repo, submodule_dir=""):
+    subdir = f"/{submodule_dir}" if submodule_dir else ''
+    github_edit_url = f"custom_edit_url: https://github.com/{repo.full_name}/blob/{repo.default_branch}{subdir}/README.yaml"
     return CUSTOM_EDIT_URL_REGEX.sub(github_edit_url, content)
 
 
@@ -89,8 +92,8 @@ def remove_prefix(string, prefix):
         return string[len(prefix):]
 
 
-def rename_name(repo, content):
-    return NAME_REGEX.sub(f'name: {repo.name}', content)
+def rename_name(name, content):
+    return NAME_REGEX.sub(f'name: {name}', content)
 
 
 def parse_terraform_repo_name(name):
@@ -119,13 +122,13 @@ def replace_relative_links_with_github_links(repo, content, relative_path=None):
         updated_link = link
 
         # remove leading './' or '/'
-        if link.startswith('./'):
-            updated_link = updated_link.replace('./', '', 1)
-        elif link.startswith('/'):
+        if link.startswith('/'):
             updated_link = updated_link.replace('/', '', 1)
-
-        if relative_path:
-            updated_link = f"{relative_path}/{updated_link}"
+        else:
+            if link.startswith('./'):
+                updated_link = updated_link.replace('./', '', 1)
+            if relative_path:
+                updated_link = f"{relative_path}/{updated_link}"
 
         content = content.replace(f"]({link})", f"](https://github.com/{repo.full_name}/tree/{repo.default_branch}/{updated_link})")
 


### PR DESCRIPTION
## what

- Warn about input errors being silently ignored with object inputs
- Remove DNS section from Terraform Best Practices
- Incorporate some changes from #584 and update some others, thanks @whyevenquestion1t
- Enhance site builder to render `README.yaml` of sub-modules when present

## why

- Non-obvious behavior can lead to serious consequences
- Recommendations about DNS configuration are not relevant to Terraform
- Supersedes and closes #584, which is not completely ready to merge and is nearly a year old
- Submodule `README.md` is expected to be plain. If it is generated by `README.yaml`, then parse it like we do for top-level modules so we do not get the extra stuff that breaks Docusaurus.
