### PR TITLE
DEV-2295: Post Release Corrections

### DIFF
--- a/scripts/docs-collator/templates/modules/readme.md
+++ b/scripts/docs-collator/templates/modules/readme.md
@@ -1,5 +1,5 @@
-{{- defineDatasource "config" .Env.README_YAML -}}
-{{- defineDatasource "readmeIncludesDir" .Env.README_INCLUDES -}}
+{{- defineDatasource "config" .Env.README_YAML | regexp.Replace ".*" "" -}}
+{{- defineDatasource "includes" .Env.README_INCLUDES | regexp.Replace ".*" "" -}}
 {{- $deprecated := has (ds "config") "deprecated" -}}
 {{- $fullModuleName := (ds "config").name -}}
 {{- $shortModuleName := (index ($fullModuleName | strings.SplitN "-" 3) 2) -}}
@@ -17,7 +17,6 @@ tags:
 {{- end }}
 custom_edit_url: https://github.com/cloudposse/{{ $fullModuleName }}/edit/main/README.md
 ---
-
 
 # Module: `{{ $shortModuleName }}`
 


### PR DESCRIPTION
## what
- Fixed the README template for rendering GitHub Actions and Terraform Modules

## why
- A commit before the staging changes was merged into these templates and broke the build
- Reverted the change

## references
- DEV-2295
```
[09-08-2024 14:11:50] WARNING {"time":"2024-08-09T14:11:50.042188-04:00","level":"ERROR","msg":"","err":"renderTemplate: failed to render template /Users/danielmiller/Documents/dev/cloudposse/docs/scripts/docs-collator/templates/modules/readme.md: template: /Users/danielmiller/Documents/dev/cloudposse/docs/scripts/docs-collator/templates/modules/readme.md:79:4: executing \"/Users/danielmiller/Documents/dev/cloudposse/docs/scripts/docs-collator/templates/modules/readme.md\" at <include \"includes\" (printf \"%s/%s\" $fullModuleName $file)>: error calling include: undefined datasource 'includes': %!w(<nil>)"}
make: *** [/Users/danielmiller/Documents/dev/cloudposse/docs/build-harness/modules/readme/Makefile:69: readme/build] Error 1
```