### PR TITLE
fix: Improved Links for Developer Onboarding

### DIFF
--- a/docs/learn/onboarding.mdx
+++ b/docs/learn/onboarding.mdx
@@ -44,11 +44,16 @@ If you're new to Terraform, we recommend starting with the [Terraform documentat
   <Step>
     ### <StepNumber/> Learn the Cloud Posse Toolchain
 
+    <figure>
+      <ReactPlayer controls url="https://docs.cloudposse.com/assets/refarch/handoffs/introduction-to-toolchain.mp4" />
+      <figcaption>AI generated voice</figcaption>
+    </figure>
+
     <TaskList>
-      - [ ] Review the [Introduction to Toolset](/layers/foundation/#-set-up-your-project) video and become familiar with the concepts
-            of [Components](/components), [Stacks](/resources/legacy/fundamentals/stacks), and
+      - [ ] Review the Introduction to Toolset video and become familiar with the concepts
+            of [Components](/components), [Stacks](https://atmos.tools/core-concepts/stacks/), and
             [Stack Catalogs](https://atmos.tools/core-concepts/stacks/catalogs)
-      - [ ] Review [Geodesic](/resources/legacy/fundamentals/geodesic) docker toolbox and
+      - [ ] Review [Geodesic](https://github.com/cloudposse/geodesic/) docker toolbox and
             [How to Customize the Geodesic Shell](/learn/maintenance/tutorials/how-to-customize-the-geodesic-shell)
             to your liking.
       - [ ] Review [atmos.tools](https://atmos.tools/)
@@ -87,7 +92,7 @@ If you're new to Terraform, we recommend starting with the [Terraform documentat
     ### <StepNumber/> How we Use Terraform (for developers)
 
     <TaskList>
-      - [ ] Review [Terraform](/resources/legacy/fundamentals/terraform) conventions used by Cloud Posse
+      - [ ] Review [Terraform](/best-practices/terraform/) conventions used by Cloud Posse
       - [ ] We store all the terraform states in S3. Make sure you understand the [Structure of Terraform S3 State Backend Bucket](/layers/accounts/tutorials/terraform-s3-state)
       - [ ] Learn
             [How to Use Terraform Remote State](/learn/maintenance/tutorials/how-to-use-terraform-remote-state) -

--- a/docs/learn/onboarding.mdx
+++ b/docs/learn/onboarding.mdx
@@ -9,6 +9,7 @@ import Steps from '@site/src/components/Steps';
 import Step from '@site/src/components/Step';
 import StepNumber from '@site/src/components/StepNumber';
 import TaskList from '@site/src/components/TaskList';
+import ReactPlayer from 'react-player';
 
 <Intro>
   This guide is intended to help new developers get up to speed with the Cloud Posse reference architecture. It covers the basics of the architecture, how to get started, and how to contribute. We assume you have a basic understanding of Terraform and AWS. We assume you are joining a team that is already using the Cloud Posse reference architecture that's been fully implemented in your AWS organization.

--- a/docs/learn/onboarding.mdx
+++ b/docs/learn/onboarding.mdx
@@ -45,7 +45,7 @@ If you're new to Terraform, we recommend starting with the [Terraform documentat
     ### <StepNumber/> Learn the Cloud Posse Toolchain
 
     <TaskList>
-      - [ ] Read through the [Introduction to Toolset](#introduction-to-toolset) slides and become familiar with the concepts
+      - [ ] Review the [Introduction to Toolset](/layers/foundation/#-set-up-your-project) video and become familiar with the concepts
             of [Components](/components), [Stacks](/resources/legacy/fundamentals/stacks), and
             [Stack Catalogs](https://atmos.tools/core-concepts/stacks/catalogs)
       - [ ] Review [Geodesic](/resources/legacy/fundamentals/geodesic) docker toolbox and


### PR DESCRIPTION
## what
- Replace invalid link for Developer Onboarding
- Replace several "legacy" links to latest location for the same content

## why
- The "Introduction to Toolset" slides have been replaced with a video
- Avoid using "legacy" links

## references
- customer request
