### PR TITLE
Fix: 1Pass SCIM Bridge Instructions 

### DIFF
--- a/docs/layers/ecs/tutorials/1password-scim-bridge.mdx
+++ b/docs/layers/ecs/tutorials/1password-scim-bridge.mdx
@@ -29,14 +29,14 @@ The implementation of this is fairly simple. We will generate credentials for th
       1. Click Integrations in the sidebar
       1. Select "Set up user provisioning"
       1. Choose "Custom"
-      1. You should now see the SCIM bridge credentials. We will need the "Bearer Token" for the next steps.
-      1. Save this token in a secure location (such as 1Password) for future reference
-      1. Store the credentials in AWS SSM Parameter Store. This will allow the ECS task definition to access the credentials securely.
+      1. You should now see the SCIM bridge credentials. We will need the "scimsession" and "Bearer Token" for the next steps.
+      1. Save these credentials in a secure location (such as 1Password) for future reference
+      1. Store the "scimsession" in AWS SSM Parameter Store. This will allow the ECS task definition to access the credentials securely. Then the server will ask for the bearer token using the session, which we will enter at that time.
 
         <Steps>
           - Open the AWS Web Console - Navigate to the target account, such as `core-auto`, and target region, such as `us-west-2`
           - Open "AWS System Manager" > "Parameter Store"
-          - Create a new Secure String parameter using the credentials you generated in the previous step: `/1password/scim/bearer-token`
+          - Create a new Secure String parameter using the credentials you generated in the previous step: `/1password/scim/scimsession`
         </Steps>
     </Steps>
 
@@ -87,7 +87,7 @@ The implementation of this is fairly simple. We will generate credentials for th
                         OP_TLS_DOMAIN: ""
                         OP_CONFIRMATION_INTERVAL: "300"
                       map_secrets:
-                        OP_SESSION: "1password/scim/bearer-token"
+                        OP_SESSION: "1password/scim/scimsession"
                         # OP_WORKSPACE_CREDENTIALS: ""
                         # OP_WORKSPACE_SETTINGS: ""
                       log_configuration:
@@ -122,15 +122,15 @@ The implementation of this is fairly simple. We will generate credentials for th
   <Step>
     ### <StepNumber/> Validate the Integration
 
-    The final step is to validate the integration. Connect to the VPN (if deployed the ECS service is deployed with a private ALB), navigate to the SCIM bridge URL, and confirm the service is running.
+    After deploying the SCIM bridge ECS service, verify the service is running and accessible. Connect to the VPN (if deployed the ECS service is deployed with a private ALB), navigate to the SCIM bridge URL, and confirm the service is running.
 
     For example, go to `https://1pass-scim.platform.usw1.auto.core.acme-svc.com/`
   </Step>
 
   <Step>
-  ### <StepNumber/> Connect your Identity Provider
+    ### <StepNumber/> Connect your Identity Provider
 
-  Finally, connect your identity provider to the SCIM bridge. The SCIM bridge URL will be the URL you validated in the previous step. Follow the instructions in the 1Password SCIM Bridge documentation to connect your identity provider.
+    Finally, connect your identity provider to the SCIM bridge. The SCIM bridge URL will be the URL you validated in the previous step. Follow the instructions in the 1Password SCIM Bridge documentation to connect your identity provider, using the Bearer Token you generated in the first step.
 
   </Step>
 

--- a/docs/layers/ecs/tutorials/1password-scim-bridge.mdx
+++ b/docs/layers/ecs/tutorials/1password-scim-bridge.mdx
@@ -31,7 +31,7 @@ The implementation of this is fairly simple. We will generate credentials for th
       1. Choose "Custom"
       1. You should now see the SCIM bridge credentials. We will need the "scimsession" and "Bearer Token" for the next steps.
       1. Save these credentials in a secure location (such as 1Password) for future reference
-      1. Store the "scimsession" in AWS SSM Parameter Store. This will allow the ECS task definition to access the credentials securely. Then the server will ask for the bearer token using the session, which we will enter at that time.
+      1. Store only the "scimsession" in AWS SSM Parameter Store. This will allow the ECS task definition to access the credentials securely. Then once the service is running, the server will ask for the bearer token to verify the connection, which we will enter at that time.
 
         <Steps>
           - Open the AWS Web Console - Navigate to the target account, such as `core-auto`, and target region, such as `us-west-2`


### PR DESCRIPTION
## what
- Update SCIM bridge credentials and integration steps

## why
- We should use the `scimsession`, not the `bearer-token`. Then enter the Bearer Token when prompted by the service

## references
- Corrects #664 
