### PR TITLE
Fix admonition regarding component migration

### DIFF
--- a/docs/components/components.mdx
+++ b/docs/components/components.mdx
@@ -5,23 +5,19 @@ sidebar_position: 0
 sidebar_class_name: hidden
 description: Library of Terraform Root Module Components
 ---
-import Intro from '@site/src/components/Intro';
-import DocCardList from '@theme/DocCardList';
 
-<Intro>
-  This is a library of reusable Terraform "root module" components.
-</Intro>
+import Intro from "@site/src/components/Intro";
+import DocCardList from "@theme/DocCardList";
 
-<DocCardList/>
+<Intro>This is a library of reusable Terraform "root module" components.</Intro>
+
+<DocCardList />
 
 :::info
-## The Components In This Repository Have Moved!
 
-We've migrated all the components to individual repositories under a [dedicated GitHub organization](https://github.com/cloudposse-terraform-components).
-All future updates, contributions, and issues should be directed to the respective component repositories in the new organization.
+## Terraform Component GitHub Repository Has Moved!
 
-[Learn more](/learn/maintenance/tutorials/how-to-update-components-yaml-to-new-organization/) how to migrate your components references to new repos.
+The GitHub repository for Cloud Posse's Terraform components has migrated to a [dedicated GitHub organization](https://github.com/cloudposse-terraform-components). All documentation remains here, but all future updates, contributions, and issue tracking for the source code should now be directed to the respective repositories in the new organization.
+
+[Learn more](/learn/maintenance/tutorials/how-to-update-components-yaml-to-new-organization/) about updating your references to point to the new repositories.
 :::
-
-
-


### PR DESCRIPTION
## what
* Clarify that the GitHub repository has moved, not the documentation

## why
* Previously we made it look like the documentation has migrated
