### PR TITLE
fix: renovate config link is broken

### DIFF
--- a/docs/learn/maintenance/upgrades/how-to-keep-everything-up-to-date.mdx
+++ b/docs/learn/maintenance/upgrades/how-to-keep-everything-up-to-date.mdx
@@ -20,7 +20,7 @@ Use [Renovatebot](https://docs.renovatebot.com/) to automatically open Pull Requ
 
 First, install the `renovate.json` config file into your repo:
 
-[https://github.com/cloudposse/renovatebot-testing-2/blob/review-branch/.github/renovate.json](https://github.com/cloudposse/renovatebot-testing-2/blob/review-branch/.github/renovate.json)
+TODO
 
 Second, add `# renovate` annotations to your code as detailed below in the `Examples` section. Although annotations may not be necessary for some dependencies (our `renovate.json` file does try to identify common dependency patterns, even in the absence of an annotation), we do recommend that you annotate where possible.
 


### PR DESCRIPTION
## what

* Cloud Posse needs a new link for the renovate config file that they shared in this doc.

## why

* Link is broken -- It goes no where.

## references

* https://docs.cloudposse.com/learn/maintenance/upgrades/how-to-keep-everything-up-to-date/
* Also, FYI folks: Your "Edit this page" link at the bottom of the docs site is broken as well. It's introducing an extra `/content/` into the URL. I didn't go digging for where this happening within your docs site generation. 

![CleanShot 2024-12-22 at 14 31 36@2x](https://github.com/user-attachments/assets/9048c611-9290-49c6-a4d2-e5a7d7be3a5a)

![Arc 2024-12-22 14 30 00](https://github.com/user-attachments/assets/906fee01-4321-4458-90e4-63c520abb3fc)

![Arc 2024-12-22 14 29 51](https://github.com/user-attachments/assets/388224c8-732e-4b89-8a56-77dfa3062f44)