### PR TITLE
fix: Corrected Dockerfile path

### DIFF
--- a/docs/layers/project/toolbox.mdx
+++ b/docs/layers/project/toolbox.mdx
@@ -10,7 +10,7 @@ import PrimaryCTA from '@site/src/components/PrimaryCTA';
 import DismissibleDialog from '@site/src/components/DismissibleDialog';
 import CodeBlock from '@theme/CodeBlock';
 import CollapsibleText from '@site/src/components/CollapsibleText';
-import PartialDockerfile from '@site/examples/snippets/components/docker/infra-acme/Dockerfile';
+import PartialDockerfile from '@site/examples/snippets/Dockerfile';
 import PartialMakefile from '@site/examples/snippets/Makefile';
 import Note from '@site/src/components/Note';
 


### PR DESCRIPTION
## what
- Set the path for the example snippet for the generated Dockerfile

## why
- We have moved the default location for the Dockerfile

## references
- https://github.com/cloudposse/refarch-scaffold/pull/740
