### PR TITLE
Argo CD GitHub App Usage

### DIFF
--- a/docs/layers/software-delivery/eks-argocd/eks-argocd.mdx
+++ b/docs/layers/software-delivery/eks-argocd/eks-argocd.mdx
@@ -9,10 +9,15 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import Note from '@site/src/components/Note';
 import CollapsibleText from '@site/src/components/CollapsibleText';
+import Admonition from '@theme/Admonition';
 
 <Intro>
 Argo CD is an open-source declarative, GitOps continuous delivery tool for Kubernetes applications. It enables developers to manage and deploy applications on Kubernetes clusters using Git repositories as the source of truth for configuration and definitions. Argo CD follows the GitOps methodology, which means that the entire application configuration, including manifests, parameters, and even application state, is stored in a Git repository.
 </Intro>
+
+<Admonition type="info" title="GitHub Integration">
+  We recommend using GitHub Apps for Argo CD integration with GitHub. GitHub Apps provide more granular permissions, better security, and improved audit capabilities compared to Personal Access Tokens (PATs). See [Setting up ArgoCD](/layers/software-delivery/eks-argocd/setup/) for details on both authentication methods.
+</Admonition>
 
 #### SAML Security Considerations
 
@@ -28,9 +33,9 @@ For more information, please see:
 - [Mattermost blog post of July 28, 2021 where `@jupenur`](https://mattermost.com/blog/securing-xml-implementations-across-the-web/)
   states:
   > If you maintain an application in Ruby, JavaScript, .NET, or Java and rely on SAML or other security-critical XML
-  > use-cases, the question burning in the back of your mind should be: “How do I patch this?” The good news is that you
+  > use-cases, the question burning in the back of your mind should be: "How do I patch this?" The good news is that you
   > should already be patched if you use Ruby or JavaScript and update your dependencies regularly. And if you use .NET
-  > or Java, there’s probably nothing to worry about.
+  > or Java, there's probably nothing to worry about.
 
 ### Overview
 

--- a/docs/layers/software-delivery/eks-argocd/eks-argocd.mdx
+++ b/docs/layers/software-delivery/eks-argocd/eks-argocd.mdx
@@ -9,15 +9,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import Note from '@site/src/components/Note';
 import CollapsibleText from '@site/src/components/CollapsibleText';
-import Admonition from '@theme/Admonition';
 
 <Intro>
 Argo CD is an open-source declarative, GitOps continuous delivery tool for Kubernetes applications. It enables developers to manage and deploy applications on Kubernetes clusters using Git repositories as the source of truth for configuration and definitions. Argo CD follows the GitOps methodology, which means that the entire application configuration, including manifests, parameters, and even application state, is stored in a Git repository.
 </Intro>
-
-<Admonition type="info" title="GitHub Integration">
-  We recommend using GitHub Apps for Argo CD integration with GitHub. GitHub Apps provide more granular permissions, better security, and improved audit capabilities compared to Personal Access Tokens (PATs). See [Setting up ArgoCD](/layers/software-delivery/eks-argocd/setup/) for details on both authentication methods.
-</Admonition>
 
 #### SAML Security Considerations
 

--- a/docs/layers/software-delivery/eks-argocd/setup.mdx
+++ b/docs/layers/software-delivery/eks-argocd/setup.mdx
@@ -2,7 +2,7 @@
 title: Setup Argo CD
 sidebar_label: Setup
 sidebar_position: 10
-description: ArgoCD is a declarative, GitOps continuous delivery tool for Kubernetes.
+description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
 ---
 import Intro from '@site/src/components/Intro';
 import KeyPoints from '@site/src/components/KeyPoints';
@@ -12,28 +12,22 @@ import StepNumber from '@site/src/components/StepNumber'
 import Admonition from '@theme/Admonition'
 import TaskList from '@site/src/components/TaskList'
 import AtmosWorkflow from '@site/src/components/AtmosWorkflow';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 <Intro>
- This setup guide will walk you through the process of setting up ArgoCD in your environment.
+ This setup guide will walk you through the process of setting up Argo CD in your environment.
 </Intro>
-
-| Steps                               | Example                                                                                                                                                 |
-| :---------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 1. Vendor ArgoCD components         | `atmos workflow vendor -f argocd`                                                                                                                       |
-| 2. Create ArgoCD repos              | ClickOps                                                                                                                                                |
-| 3. Create GitHub PATs               | [ArgoCD Integrations: How to set up Authorization for ArgoCD with GitHub PATs](/layers/software-delivery/eks-argocd/tutorials/pats)          |
-| 4. Deploy ArgoCD repo configuration | `atmos workflow deploy/argocd-repos -f argocd`                                                                                                          |
-| 5. Create IAM Identity Center Apps  | [ArgoCD Integrations: How to create an AWS Identity Center Application](/layers/software-delivery/eks-argocd/tutorials/identity-center-apps) |
-| 6. Deploy ArgoCD                    | `atmos workflow deploy/argocd -f argocd`                                                                                                                |
-| 7. Create `example-app`             | ClickOps                                                                                                                                                |
 
 ## Requirements
 
-In order to deploy ArgoCD, EKS must be fully deployed and functional. In particular, the user deploying the cluster must
+In order to deploy Argo CD, EKS must be fully deployed and functional. In particular, the user deploying the cluster must
 have a working VPN connection to the targeted account. See
 [the EKS documentation](/layers/eks/deploy-clusters/) for details.
 
 All deployment steps below assume that the environment has been successfully set up with the following steps.
+
+### Authentication
 
 <Steps>
   1. Sign into AWS via Leapp
@@ -41,89 +35,195 @@ All deployment steps below assume that the environment has been successfully set
   1. Open Geodesic
 </Steps>
 
-<Steps>
-  # Steps
-  <Step>
-    ## <StepNumber/> Vendor Components
+## Setup Steps
 
-    First vendor all related components for the ArgoCD layer:
+<Steps>
+  <Step>
+    ## <StepNumber/> Vendor Argo CD components
+
+    First vendor all related components for the Argo CD layer:
 
     <AtmosWorkflow workflow="vendor" fileName="argocd" />
   </Step>
 
   <Step>
-
-    ## <StepNumber/> Establish a Bot User
-
-    We deploy a number of GitHub Personal Access Tokens (PATs) as part of the EKS with ArgoCD application. By default each
-    PAT is given the least-access required for the given job.
-
-    Each one of these PATs will be associated with a given user. We recommend creating or using an existing "bot" user. For
-    example, at Cloud Posse we have the "cloudpossebot" GitHub user. This user has its own email address and GitHub account,
-    is accessible from our internal 1Password vault for all privileged users, and has all access keys and tokens stored with
-    it in 1Password.
-
-    This bot user will need permission to manage a few repositories in your Organization. If you wish to simplify
-    deployment, you can grant this user permission to create repositories. See (Create Permission for the Bot User)[#Create
-    Permission for the Bot User].
-
-    Use this bot user for all access tokens in the remainder of this guide.
-  </Step>
-
-  <Step>
-    ## <StepNumber/> Create ArgoCD GitHub Repositories
+    ## <StepNumber/> Create Argo CD GitHub Repositories
 
     <Steps>
-      - Create the two required ArgoCD GitHub repos:
+      - Create the two required Argo CD GitHub repos:
         <TaskList>
         - [acme/argocd-deploy-non-prod](https://github.com/acme/argocd-deploy-non-prod)
         - [acme/argocd-deploy-prod](https://github.com/acme/argocd-deploy-prod)
         </TaskList>
-
-      - Then grant the bot user `Admin` access to these two repositories.
     </Steps>
   </Step>
 
   <Step>
-    ## <StepNumber/> Create all ArgoCD PATs
+    ## <StepNumber/> Prepare Authentication
 
-    We will need several PATs for the following steps. Now that the ArgoCD repos are created, you can create all required
-    PATs.
+    Argo CD can be integrated with GitHub using either GitHub Apps (recommended) or Personal Access Tokens (PATs). GitHub Apps provide more granular permissions, better security, and improved audit capabilities.
 
-    Please see
-    [ArgoCD Integrations: How to set up Authorization for ArgoCD with GitHub PATs](/layers/software-delivery/eks-argocd/tutorials/pats)
-    and follow all steps.
+    Argo CD requires several different types of GitHub authentication for various components and workflows. While these could be combined, we follow the principle of least privilege by creating separate authentication credentials for each specific purpose. The following authentication methods are required:
+
+    <Steps>
+    1. #### Terraform `argocd-repo` Access
+       The first PAT is used by Terraform with the `argocd-repo` component. This is used to create and manage the Argo CD desired state repositories and (optionally) add deployment ssh keys for those repos.
+
+       Terraform will pull that PAT from SSM typically using the `argocd/github` path in the `core-auto` account.
+
+       Alternatively, you can required local access to apply the component. This would require an engineer to locally authenticate with GitHub and apply this component locally. Since this component is rarely updated, this can be a reasonable trade-off.
+
+       At this time, we do not have GitHub App support for this step and prefer using local developer access.
+
+    2. #### Terraform `eks/argocd` Access
+
+       The next two PATs or GitHub App installations are also used by Terraform now with the `eks/argocd` component. Each of these is used to register the webhook in GitHub for the Argo CD Application created with this given component. One is used for non-prod stages and the other is used for prod stages.
+
+       Terraform will pull that token from SSM typically in `plat-dev`, `plat-staging`, and `plat-prod` accounts. 
+
+    3. #### Argo CD GitHub Notification Access
+
+       The next PAT or GitHub App token is used by the Argo CD notifications system to set the GitHub to commit status on successful deployments. This is stored in SSM and pulled by the `eks/argocd` component. That component will pass the token to the Argo CD instance in the given EKS cluster. That Argo CD instance uses that token _only when synchronous mode is enabled_.
+
+    4. #### GitHub Release Workflow Access
+
+       The final two PATs or GitHub App installations are used in the release engineering workflows: one for non-prod and one for prod. This token should allow write permissions in the given Argo CD desired state repositories.
+
+    </Steps>
+
+    <Tabs queryString="auth-method">
+      <TabItem value="github-apps" label="GitHub Apps (Recommended)">
+        <Steps>
+          <Step>
+            ## <StepNumber/> Set up GitHub Apps
+
+            Follow the instructions in [Argo CD Integrations: How to set up Authorization for Argo CD with GitHub Apps](/layers/software-delivery/eks-argocd/tutorials/github-apps) to create and configure a GitHub App for Argo CD.
+          </Step>
+
+          <Step>
+            ## <StepNumber/> Configure Argo CD Desire State Repositories to Use GitHub Apps
+
+            Update your Argo CD desired state repository configuration to use the GitHub App instead of PAT:
+
+            ```yaml
+            components:
+              terraform:
+                argocd-repo:
+                  vars:
+                    # 1. Use local access to apply this component rather than a PAT
+                    # https://registry.terraform.io/providers/integrations/github/latest/docs#github-cli
+                    use_local_github_credentials: true
+
+                    # 2. If synchronous mode is enabled, set the notifications to send to "github" and not to the "webhook"
+                    github_notifications:
+                      - "notifications.argoproj.io/subscribe.on-deploy-started.github: \"\""
+                      - "notifications.argoproj.io/subscribe.on-deploy-succeeded.github: \"\""
+                      - "notifications.argoproj.io/subscribe.on-deploy-failed.github: \"\""
+
+                    # 3. Optional, disable the SSH deploy keys to use a GitHub App 
+                    #    for the Argo CD instance to authenticate with the desired state repository
+                    deploy_keys_enabled: false
+            ```
+
+          </Step>
+
+          <Step>
+            ## <StepNumber/> Configure Argo CD to Use GitHub Apps
+
+            Update your Argo CD configuration to use the GitHub App instead of PATs:
+
+            ```yaml
+            components:
+              terraform:
+                eks/argocd:
+                  vars:
+                    # GitHub App (Argo CD Instance)
+                    # This GitHub App is used for the Argo CD instance to manage webhooks and read from the desired state repository.
+                    # ie https://github.com/acme/argocd-deploy-non-prod
+                    github_app_enabled: true
+                    github_app_id: "1234567"
+                    github_app_installation_id: "44444444"
+                    # The SSM parameter must exist in the account and region where Argo CD is deployed.
+                    ssm_github_app_private_key: "/argocd/argo_cd_instance/app_private_key"
+                    # Optional, disable the SSH deploy keys to use this GitHub App 
+                    # for the Argo CD instance to authenticate with the desired state repository
+                    github_deploy_keys_enabled: false
+
+                    # GitHub App (Argo CD Notifications)
+                    # This GitHub App is used for the Argo CD instance to send commit status updates back to each ap repository.
+                    # This is only required if synchronous mode is enabled.
+                    # ie https://github.com/acme/example-app-on-eks
+                    github_notifications_app_enabled: true
+                    github_notifications_app_id: "8901235"
+                    github_notifications_app_installation_id: "55555555"
+                    # The SSM parameter must exist in the account and region where Argo CD is deployed.
+                    ssm_github_notifications_app_private_key: "/argocd/argo_cd_notifications/app_private_key"
+            ```
+          </Step>
+
+        </Steps>
+      </TabItem>
+      <TabItem value="pats" label="Personal Access Tokens (Legacy)">
+        <Steps>
+          <Step>
+            ## <StepNumber/> Establish a Bot User
+
+            We deploy a number of GitHub Personal Access Tokens (PATs) as part of the EKS with Argo CD application. By default each
+            PAT is given the least-access required for the given job.
+
+            Each one of these PATs will be associated with a given user. We recommend creating or using an existing "bot" user. For
+            example, at Cloud Posse we have the "cloudpossebot" GitHub user. This user has its own email address and GitHub account,
+            is accessible from our internal 1Password vault for all privileged users, and has all access keys and tokens stored with
+            it in 1Password.
+
+            This bot user will need permission to manage a few repositories in your Organization. If you wish to simplify
+            deployment, you can grant this user permission to create repositories. See (Create Permission for the Bot User)[#Create
+            Permission for the Bot User].
+
+            Use this bot user for all access tokens in the remainder of this guide.
+          </Step>
+
+          <Step>
+            ## <StepNumber/> Create all Argo CD PATs
+
+            We will need several PATs for the following steps. Now that the Argo CD repos are created, you can create all required
+            PATs.
+
+            Please see
+            [Argo CD Integrations: How to set up Authorization for Argo CD with GitHub PATs](/layers/software-delivery/eks-argocd/tutorials/pats)
+            and follow all steps.
+          </Step>
+        </Steps>
+      </TabItem>
+    </Tabs>
   </Step>
 
   <Step>
-    ## <StepNumber/> Deploy ArgoCD GitHub Repositories Configuration
+    ## <StepNumber/> Deploy Argo CD repo configuration
 
-    Deploy the ArgoCD configuration for the two GitHub repos with the following workflow:
+    Deploy the Argo CD configuration for the two GitHub repos with the following workflow:
 
     <AtmosWorkflow workflow="deploy/argocd-repos" fileName="argocd" />
 
-    Once this finishes, review the two repos in your GitHub Organization. These should both be fully configured at this
-    point.
+    Once this finishes, review the two repos in your GitHub Organization. These should both be fully configured at this point.
 
     - [acme/argocd-deploy-non-prod](https://github.com/acme/argocd-deploy-non-prod)
     - [acme/argocd-deploy-prod](https://github.com/acme/argocd-deploy-prod)
-
-    Now that the ArgoCD deployment repos are configured, we need to create GitHub PATs for ArgoCD.
   </Step>
 
   <Step>
     ## <StepNumber/> Create AWS Identity Center Applications
 
-    In order to authenticate with ArgoCD, we recommend using an AWS IAM Identity Center SAML Application. These apps can use existing Identity Center groups that we've already setup as part of the [Identity layer](/layers/identity/).
+    In order to authenticate with Argo CD, we recommend using an AWS IAM Identity Center SAML Application. These apps can use existing Identity Center groups that we've already setup as part of the [Identity layer](/layers/identity/).
 
-    Please see [ArgoCD Integrations: How to create an AWS Identity Center Application](/layers/software-delivery/eks-argocd/tutorials/identity-center-apps) and follow all steps.
+    Please see [Argo CD Integrations: How to create an AWS Identity Center Application](/layers/software-delivery/eks-argocd/tutorials/identity-center-apps) and follow all steps.
   </Step>
 
   <Step>
-    ### <StepNumber/> Deploy ArgoCD to each EKS Cluster
+    ## <StepNumber/> Deploy Argo CD to each EKS Cluster
 
     Once the GitHub repositories are in place and the SAML applications have been created and configuration uploaded to SSM,
-    we're ready to deploy ArgoCD to each cluster.
+    we're ready to deploy Argo CD to each cluster.
 
     Deploy `eks/argocd` to each cluster with the following workflow:
 
@@ -133,7 +233,7 @@ All deployment steps below assume that the environment has been successfully set
   <Step>
     ## <StepNumber/> Validation
 
-    Once all deployment steps are completed, ArgoCD should be accessible at the following URLs. Please note that you must be
+    Once all deployment steps are completed, Argo CD should be accessible at the following URLs. Please note that you must be
     able to authenticate with AWS Identity Center to access any given app.
     <TaskList>
       - https://argocd.use1.dev.plat.acme-svc.com
@@ -145,7 +245,7 @@ All deployment steps below assume that the environment has been successfully set
 
 ## Next Steps
 
-Assuming login goes well, here's a checklist of GitHub repos needed to connect ArgoCD:
+Assuming login goes well, here's a checklist of GitHub repos needed to connect Argo CD:
 
 <TaskList>
   - [ ] `acme/infra-acme` repo (Should already exist!)
@@ -153,7 +253,7 @@ Assuming login goes well, here's a checklist of GitHub repos needed to connect A
           workflows. This directory stores private environment configurations. Primarily, that is the
           [`cloudposse/github-action-yaml-config-query`](https://github.com/cloudposse/github-action-yaml-config-query)
           action used to get role, namespace, and cluster mapping for each environment.
-  - [ ] (2) ArgoCD deploy nonprod and prod (Should already be created by `argocd-repo` component in earlier step)
+  - [ ] (2) Argo CD deploy nonprod and prod (Should already be created by `argocd-repo` component in earlier step)
     - [ ] `argocd-deploy-non-prod`
     - [ ] `argocd-deploy-prod`
   - [ ] `acme/example-app` repo should be private repo generated from the
@@ -226,7 +326,7 @@ public.
 
 ## FAQ
 
-### Migrating from ArgoCD version `<1.305.0` to `1.305.0`
+### Migrating from Argo CD version `<1.305.0` to `1.305.0`
 
 In order to migrate to `1.305.0` from a lesser version, delete the previous SSM parameters in each account for
 `/argocd/notifications/notifiers/service_webhook_github-commit-status/github-token` and redeploy `github-webhook-pat`,
@@ -236,28 +336,20 @@ Or use the following workflow:
 
 <AtmosWorkflow workflow="migrate_less_1_305" fileName="argocd" />
 
-### About GitHub PATs
+### GitHub Apps vs Personal Access Tokens
 
-We deploy a number of GitHub Personal Access Tokens (PAT). Each has a specific purpose and is limited to the
-fine-grained scope required by that specific job. These are as follows:
+We recommend using GitHub Apps for Argo CD integration with GitHub. GitHub Apps offer several advantages over Personal Access Tokens:
 
-1. #### Terraform `argocd-repo` Access
-   The first PAT we deploy is used by Terraform with the `argocd-repo` component. This PAT is used to create and manage the ArgoCD deployment repositories, add deployment ssh keys for those repos, and is stored in AWS SSM Parameter Store.
+1. **Granular Permissions**: GitHub Apps can be granted access to specific repositories rather than requiring organization-wide access.
 
-   Terraform will pull that PAT from SSM typically using the `argocd/github` path in the `core-auto` account.
+2. **Better Security**: GitHub Apps use JWT authentication and short-lived tokens, reducing the risk of token exposure.
 
-2. #### Terraform `eks/argocd` Access
+3. **Improved Audit Capabilities**: Actions performed by GitHub Apps are clearly identified in audit logs.
 
-   The next two PATs are also used by Terraform now with the `eks/argocd` component. Each of these PATs is used to register the webhook in GitHub for the ArgoCD Application created with this given component.
+4. **Rate Limiting**: GitHub Apps have their own rate limits, separate from user-based limits.
 
-   Terraform will pull that PAT from SSM typically using the `argocd/github` path in `plat-dev`, `plat-staging`, and `plat-prod` accounts. You may notice this is the same path as #1 above. These PATs can be combined into a single PAT, as both are only used by Terraform.
+5. **Webhook Support**: GitHub Apps can receive webhooks for events in repositories they have access to.
 
-3. #### ArgoCD GitHub Notification Access
+6. **Multiple Installations**: The same GitHub App can be installed on different repositories with different permissions.
 
-   The next PAT is used by the ArgoCD notifications system to set the GitHub to commit status on successful deployments. This PAT is stored in SSM and pulled by the `eks/argocd` component. That component will pass the token to the ArgoCD application in the given EKS cluster. That ArgoCD Application uses that PAT only when synchronous mode is enabled.
-
-   We store this PAT in SSM using the `argocd/notifications/notifiers/common/github-token` path
-
-4. #### GitHub Release Workflow Access
-
-  The final two PATs are used in the release engineering workflows; one for nonprod and one for prod. This token should allow write permissions in `infra-acme` and the given ArgoCD deploy repo.
+For more information on setting up Argo CD with GitHub Apps, see [Argo CD Integrations: How to set up Authorization for Argo CD with GitHub Apps](/layers/software-delivery/eks-argocd/tutorials/github-apps).

--- a/docs/layers/software-delivery/eks-argocd/setup.mdx
+++ b/docs/layers/software-delivery/eks-argocd/setup.mdx
@@ -71,7 +71,7 @@ All deployment steps below assume that the environment has been successfully set
 
        Terraform will pull that PAT from SSM typically using the `argocd/github` path in the `core-auto` account.
 
-       Alternatively, you can required local access to apply the component. This would require an engineer to locally authenticate with GitHub and apply this component locally. Since this component is rarely updated, this can be a reasonable trade-off.
+       Alternatively, you can enforce local access to apply the component. This would require an engineer to locally authenticate with GitHub and apply this component locally. Since this component is rarely updated, this can be a reasonable trade-off.
 
        At this time, we do not have GitHub App support for this step and prefer using local developer access.
 
@@ -83,7 +83,7 @@ All deployment steps below assume that the environment has been successfully set
 
     3. #### Argo CD GitHub Notification Access
 
-       The next PAT or GitHub App token is used by the Argo CD notifications system to set the GitHub to commit status on successful deployments. This is stored in SSM and pulled by the `eks/argocd` component. That component will pass the token to the Argo CD instance in the given EKS cluster. That Argo CD instance uses that token _only when synchronous mode is enabled_.
+       The next PAT or GitHub App token is used by the Argo CD notifications system to update the GitHub commit status on deployments. This is stored in SSM and pulled by the `eks/argocd` component. That component will pass the token to the Argo CD instance in the given EKS cluster. That Argo CD instance uses that token _only when synchronous mode is enabled_.
 
     4. #### GitHub Release Workflow Access
 

--- a/docs/layers/software-delivery/eks-argocd/tutorials/github-apps.mdx
+++ b/docs/layers/software-delivery/eks-argocd/tutorials/github-apps.mdx
@@ -1,0 +1,318 @@
+---
+title: "How to set up Authorization for Argo CD with GitHub Apps"
+sidebar_label: "Authorization (GitHub Apps)"
+sidebar_position: 25
+tags:
+  - argocd
+  - github
+  - eks
+  - github-apps
+---
+import Intro from '@site/src/components/Intro';
+import KeyPoints from '@site/src/components/KeyPoints';
+import Steps from '@site/src/components/Steps'
+import Step from '@site/src/components/Step'
+import StepNumber from '@site/src/components/StepNumber'
+import Admonition from '@theme/Admonition'
+import Note from '@site/src/components/Note'
+import AtmosWorkflow from '@site/src/components/AtmosWorkflow';
+
+<Intro>
+  GitHub Apps is now the preferred method for Argo CD integration with GitHub. GitHub Apps provide more granular permissions, better security, and improved audit capabilities compared to Personal Access Tokens (PATs). This guide will walk you through setting up Argo CD with GitHub Apps.
+</Intro>
+
+<KeyPoints>
+  - GitHub Apps provide more granular permissions than PATs
+  - GitHub Apps can be installed on specific repositories
+  - GitHub Apps have built-in rate limiting and audit capabilities
+  - GitHub Apps can be used for both repository management and notifications
+</KeyPoints>
+
+## Required GitHub Apps
+
+Argo CD integration requires multiple GitHub Apps, each with specific permissions and repository scopes:
+
+### 1. Argo CD Instance
+- **Actor**: Argo CD Deployment in Kubernetes
+- **Use cases and permissions**:
+  - Allow Argo CD to read from Desired State Repositories:
+    - `repository.contents`: Read-Only
+    - `repository.metadata`: Read-Only
+  - Webhooks for Desired State Repositories:
+    - `repository.webhooks`: Read and Write
+    - `repository.metadata`: Read-Only
+- **Repository scope**:
+  - `acme/argocd-deploy-non-prod`
+  - `acme/argocd-deploy-prod`
+
+### 2. Argo CD Deploy Non-prod
+- **Actor**: GitHub App IAT supplied to GitHub Actions Workflows
+- **Use cases and permissions**:
+  - Push commits to Desired State Repositories
+    - `repository.contents`: Read and Write
+    - `repository.metadata`: Read-Only
+- **Repository scope**:
+  - `acme/argocd-deploy-non-prod`
+
+### 3. Argo CD Deploy Prod
+- **Actor**: GitHub App IAT supplied to GitHub Actions Workflows
+- **Use cases and permissions**:
+  - Push commits to Desired State Repositories
+    - `repository.contents`: Read and Write
+    - `repository.metadata`: Read-Only
+- **Repository scope**:
+  - `acme/argocd-deploy-prod`
+
+### 4. Argo CD Notifications
+- **Use cases and permissions**:
+  - Commit status API (relay commit statuses from Desired State Repositories to app repositories via notification templates in `eks/argocd`):
+    - `repository.commit_statuses`: Write
+- **Repository scope**:
+  - All of the app repositories
+
+## Compensating Controls
+
+To address security concerns, the following compensating controls should be implemented:
+
+1. **Organization-Level Branch Ruleset**:
+   - Applied to all app repos but *not* to `acme/argocd-deploy-non-prod` and `acme/argocd-deploy-prod`
+   - Prevents changes to the main branch with the Argo CD app *not* in the bypass list
+   - The Argo CD repos are excluded because workflows need to write to the main branch in these repos
+
+2. **Argo CD Desired State Repositories Branch Ruleset**:
+   - Applied only to the Argo CD desired state repositories
+   - Prevents writing to the main branch, but with the Argo CD app in the bypass list
+
+## Deployment
+
+<Steps>
+  <Step>
+    ### <StepNumber/> Create GitHub Apps
+
+    First, you need to create the required GitHub Apps in your organization:
+
+    <Steps>
+      1. Go to your GitHub organization settings
+      2. Navigate to "GitHub Apps" and click "New GitHub App"
+      3. Create the following GitHub Apps with their respective permissions:
+
+        #### Argo CD Instance
+        - Name: `Argo CD Instance`
+        - Homepage URL: Your organization's homepage
+        - Webhook: Disabled
+        - Permissions:
+          - Allow Argo CD to read from Desired State Repositories:
+              - `repository.contents`: Read-Only
+              - `repository.metadata`: Read-Only
+          - Webhooks for Desired State Repositories:
+              - `repository.webhooks`: Read and Write
+              - `repository.metadata`: Read-Only
+
+        #### Argo CD Deploy Non-prod
+        - Name: `Argo CD Deploy Non-prod`
+        - Homepage URL: Your organization's homepage
+        - Webhook: Disabled
+        - Permissions:
+          - Push commits to Desired State Repositories:
+            - `repository.contents`: Read and Write
+            - `repository.metadata`: Read-Only
+
+         #### Argo CD Deploy Prod
+         - Name: `Argo CD Deploy Prod`
+         - Homepage URL: Your organization's homepage
+         - Webhook: Disabled
+        - Permissions:
+          - Push commits to Desired State Repositories:
+            - `repository.contents`: Read and Write
+            - `repository.metadata`: Read-Only
+
+        #### Argo CD Notifications
+        - Name: `Argo CD Notifications`
+        - Homepage URL: Your organization's homepage
+        - Webhook: Disabled
+        - Permissions:
+          - Commit status API (relay commit statuses from Desired State Repositories to app repositories via notification templates in `eks/argocd`):
+            - `repository.commit_statuses`: Write
+
+    </Steps>
+  </Step>
+
+  <Step>
+    ### <StepNumber/> Generate and Store GitHub App Credentials
+
+    After creating each GitHub App, you need to generate and store credentials:
+
+    <Steps>
+      1. For each GitHub App:
+        <Steps>
+         1. On the GitHub App page, scroll down to "Private keys" and click "Generate a private key"
+         1. Download the private key file
+         1. Store the App ID, Installation ID, and private key securely in 1Password
+        </Steps>
+      2. Upload these credentials to AWS SSM Parameter Store:
+         Save these credentials to AWS SSM at the [paths specified by the `eks/argocd` component](/layers/software-delivery/eks-argocd/setup/#-configure-argo-cd-to-use-github-apps)
+    </Steps>
+  </Step>
+
+  <Step>
+    ### <StepNumber/> Install the GitHub Apps
+
+    Install each GitHub App on its required repositories:
+
+    <Steps>
+      1. For `Argo CD Instance`:
+         - Go to the GitHub App settings page
+         - Click "Install App" in the sidebar
+         - Select the repositories:
+           - `acme/argocd-deploy-non-prod`
+           - `acme/argocd-deploy-prod`
+         - Complete the installation
+
+      2. For `Argo CD Deploy Non-Prod`:
+         - Go to the GitHub App settings page
+         - Click "Install App" in the sidebar
+         - Select the repository:
+           - `acme/argocd-deploy-non-prod`
+         - Complete the installation
+
+      3. For `Argo CD Deploy Prod`:
+         - Go to the GitHub App settings page
+         - Click "Install App" in the sidebar
+         - Select the repository:
+           - `acme/argocd-deploy-prod`
+         - Complete the installation
+
+      4. For `Argo CD Notifications`:
+         - Go to the GitHub App settings page
+         - Click "Install App" in the sidebar
+         - Select all app repositories, such as `acme/example-app-on-eks`
+         - Complete the installation
+    </Steps>
+  </Step>
+
+  <Step>
+    ### <StepNumber/> Configure Branch Protection Rules
+
+    Set up the compensating controls by configuring branch protection rules:
+
+    **Organization-Level Branch Ruleset**:
+
+    <Steps>
+     - Go to your organization settings
+     - Navigate to "Code, planning, and automation" > "Branch rules"
+     - Create a new ruleset that applies to all app repos except `acme/argocd-deploy-non-prod` and `acme/argocd-deploy-prod`
+     - Configure the ruleset to prevent changes to the main branch with the Argo CD app not in the bypass list
+    </Steps>
+
+    **Argo CD Desired State Repositories Branch Ruleset**:
+
+    <Steps>
+     - Create a separate ruleset that applies only to `acme/argocd-deploy-non-prod` and `acme/argocd-deploy-prod`
+     - Configure the ruleset to prevent writing to the main branch, but with the Argo CD app in the bypass list
+    </Steps>
+  </Step>
+
+  <Step>
+    ## <StepNumber/> Configure Argo CD Desire State Repositories to Use GitHub Apps
+
+    Update your Argo CD desired state repository configuration to use the GitHub App instead of PAT:
+
+    ```yaml
+    components:
+      terraform:
+        argocd-repo:
+          vars:
+            # 1. Use local access to apply this component rather than a PAT
+            # https://registry.terraform.io/providers/integrations/github/latest/docs#github-cli
+            use_local_github_credentials: true
+
+            # 2. If synchronous mode is enabled, set the notifications to send to "github" and not to the "webhook"
+            github_notifications:
+              - "notifications.argoproj.io/subscribe.on-deploy-started.github: \"\""
+              - "notifications.argoproj.io/subscribe.on-deploy-succeeded.github: \"\""
+              - "notifications.argoproj.io/subscribe.on-deploy-failed.github: \"\""
+
+            # 3. Optional, disable the SSH deploy keys to use a GitHub App 
+            #    for the Argo CD instance to authenticate with the desired state repository
+            deploy_keys_enabled: false
+    ```
+
+  </Step>
+
+  <Step>
+    ### <StepNumber/> Configure Argo CD to Use GitHub Apps
+
+    Update your Argo CD configuration to use the GitHub Apps instead of PATs:
+
+    ```yaml
+    components:
+      terraform:
+        eks/argocd:
+          vars:
+            # GitHub App (Argo CD Instance)
+            # This GitHub App is used for the Argo CD instance to manage webhooks and read from the desired state repository.
+            # ie https://github.com/acme/argocd-deploy-non-prod
+            github_app_enabled: true
+            github_app_id: "1234567"
+            github_app_installation_id: "44444444"
+            # The SSM parameter must exist in the account and region where Argo CD is deployed.
+            ssm_github_app_private_key: "/argocd/argo_cd_instance/app_private_key"
+            # Optional, disable the SSH deploy keys to use this GitHub App 
+            # for the Argo CD instance to authenticate with the desired state repository
+            github_deploy_keys_enabled: false
+
+            # GitHub App (Argo CD Notifications)
+            # This GitHub App is used for the Argo CD instance to send commit status updates back to each ap repository.
+            # This is only required if synchronous mode is enabled.
+            # ie https://github.com/acme/example-app-on-eks
+            github_notifications_app_enabled: true
+            github_notifications_app_id: "8901235"
+            github_notifications_app_installation_id: "55555555"
+            # The SSM parameter must exist in the account and region where Argo CD is deployed.
+            ssm_github_notifications_app_private_key: "/argocd/argo_cd_notifications/app_private_key"
+    ```
+  </Step>
+
+  <Step>
+    ### <StepNumber/> Deploy the updated configuration
+
+    Redeploy both the `argocd-repo` component for both nonprod and prod.
+
+    <AtmosWorkflow workflow="deploy/argocd-repos" fileName="argocd" />
+
+    Then redeploy all instances of `eks/argocd`
+
+    <AtmosWorkflow workflow="deploy/argocd" fileName="argocd" />
+
+  </Step>
+
+  <Step>
+    ### <StepNumber/> Configure GitHub Actions Workflows
+
+    Update your GitHub Actions workflows to use the appropriate GitHub App. 
+    
+    Set the following GitHub environment variables for the application repositories:
+    
+    1. Set `ARGO_CD_DEPLOY_NONPROD_APP_ID` in both `preview` and `dev`
+    2. Set `ARGO_CD_DEPLOY_PROD_APP_ID` in `staging` and `prod`.
+
+    Then set the following secrets:
+    
+    1. Add `ARGO_CD_DEPLOY_NONPROD_APP_PRIVATE_KEY` to `preview` and `dev`.
+    2. Add `ARGO_CD_DEPLOY_PROD_APP_PRIVATE_KEY` to `staging` and `prod`.
+
+    \**Add QA environments if necessary*
+
+    <Note title="Workflows Might Need Updating!">
+
+    Please be sure to update your GitHub Workflows to support GitHub App authentication. If you are unsure, please reach out to Cloud Posse.
+
+    </Note>
+
+  </Step>
+</Steps>
+
+## References
+- [Setting up Argo CD](/layers/software-delivery/eks-argocd/setup/)
+- [GitHub Apps Documentation](https://docs.github.com/en/developers/apps)
+- [GitHub Apps Permissions](https://docs.github.com/en/developers/apps/building-github-apps/setting-permissions-for-github-apps) 


### PR DESCRIPTION
## what
- Document using GitHub Apps for Argo CD rather than GitHub PATs

## why
- GitHub Apps are now supported for Argo CD as the preferred auth method.

## references
- .
