### PR TITLE
chore: Deprecated `#refarch` References

### DIFF
--- a/docs/community/community.mdx
+++ b/docs/community/community.mdx
@@ -35,15 +35,14 @@ import PrimaryCTA from '@site/src/components/PrimaryCTA'
   <Step>
     ## <StepNumber/> Join our GitHub Discussions
 
-    GitHub Discussions is a great place to ask questions, share ideas, and get feedback from the community. We have a dedicated section for support and questions related to the reference architecture.
+    [Cloud Posse GitHub Discussions](https://github.com/orgs/cloudposse/discussions) is a great place to ask questions, share ideas, and get feedback from the community. We have a dedicated section for support and questions related to the reference architecture.
 
     Please search through existing discussions before creating a new one. If you do not find an answer, please feel free to create a new discussion.
-
-    [Cloud Posse GitHub Discussions](https://github.com/orgs/cloudposse/discussions)
 
     <Note title="Tip!">
       Essential Support guarantees priority responses, so you always have a direct line to Cloud Posse’s expertise. Learn more about our support offerings at [https://cloudposse.com/support](https://cloudposse.com/support).
     </Note>
+  </Step>
 
   <Step>
     ## <StepNumber/> Attend Weekly Office Hours

--- a/docs/community/community.mdx
+++ b/docs/community/community.mdx
@@ -25,16 +25,25 @@ import PrimaryCTA from '@site/src/components/PrimaryCTA'
   <Step>
     ## <StepNumber/> Sign up for our SweetOps Slack
 
-    Join our free SweetOps Slack community, hosted by Cloud Posse with more than 9,500 members worldwide. While we primarily address questions in channels like `#atmos`, `#aws`, `#cloudposse`, `#geodesic`, `#github-actions`, `#refarch`, and `#terraform`, feel free to engage in any channel.
+    Join our free SweetOps Slack community, hosted by Cloud Posse with more than 9,500 members worldwide. While we primarily address questions in channels like `#atmos`, `#aws`, `#cloudposse`, `#geodesic`, `#github-actions`, and `#terraform`, feel free to engage in any channel.
 
     Sign up here: [https://slack.sweetops.com](https://slack.sweetops.com).
 
     Archives are searchable at [archive.sweetops.com](https://archive.sweetops.com).
+  </Step>
+
+  <Step>
+    ## <StepNumber/> Join our GitHub Discussions
+
+    GitHub Discussions is a great place to ask questions, share ideas, and get feedback from the community. We have a dedicated section for support and questions related to the reference architecture.
+
+    Please search through existing discussions before creating a new one. If you do not find an answer, please feel free to create a new discussion.
+
+    [Cloud Posse GitHub Discussions](https://github.com/orgs/cloudposse/discussions)
 
     <Note title="Tip!">
-      Reach out in the `#refarch` channel with questions specific to Cloud Posse architecture.
+      Essential Support guarantees priority responses, so you always have a direct line to Cloud Posse’s expertise. Learn more about our support offerings at [https://cloudposse.com/support](https://cloudposse.com/support).
     </Note>
-  </Step>
 
   <Step>
     ## <StepNumber/> Attend Weekly Office Hours

--- a/docs/resources/adrs/adrs.mdx
+++ b/docs/resources/adrs/adrs.mdx
@@ -7,7 +7,7 @@ import DocCardList from '@theme/DocCardList'
 
 These are the records of why Cloud Posse made various decisions in the design of the Reference Architecture. These decisions may differ from what your organization has decided due to going through the "Design Decisions" process.
 
-Send requests for additional documentation in the `#refarch` channel.
+Send requests for additional documentation in [GitHub Discussions](https://github.com/orgs/cloudposse/discussions).
 
 ## Records
 

--- a/docs/resources/architecture-diagrams.mdx
+++ b/docs/resources/architecture-diagrams.mdx
@@ -11,7 +11,7 @@ We provide a number of boilerplate architecture diagrams. Think of them as templ
 
 ## Available Diagrams
 
-Don’t see the diagram you need? Let us know via the `#refarch` channel.
+Don’t see the diagram you need? Open a [GitHub Discussion](https://github.com/orgs/cloudposse/discussions) to raise the request!
 
 ## 4 Layers of Infrastructure
 

--- a/docs/resources/legacy/code-of-conduct.mdx
+++ b/docs/resources/legacy/code-of-conduct.mdx
@@ -40,8 +40,6 @@ We invite all those who participate in SweetOps to help us create safe and posit
 
 - Check out the channel’s topic and purpose in order to stay on point
 
-- Use the `#refarch-general` channel if nothing else fits
-
 - Use threads when responding, especially in busy channels
 
 - Don’t use `@channel` and `@here` (we've disabled them)


### PR DESCRIPTION
## what
- removed all occurrences of `#refarch`

## why
- We have archived that channel and now require all support questions in GitHub Discussions

## references
- https://github.com/orgs/cloudposse/discussions