### PR TITLE
fixes markdown synthax for link

### DIFF
--- a/docs/layers/software-delivery/eks-argocd/tutorials/pats.mdx
+++ b/docs/layers/software-delivery/eks-argocd/tutorials/pats.mdx
@@ -35,7 +35,7 @@ Fine-grained PATs are preferred to classic PATs. All PATs except the Notificatio
 
     Each one of these PATs will be associated with a given user. We recommend creating or using an existing "bot" user. For example, at Cloud Posse we have the "cloudpossebot" GitHub user. This user has its own email address and GitHub account, is accessible from our internal 1Password vault for all privileged users, and has all access keys and tokens stored with it in 1Password.
 
-    This bot user will need permission to manage a few repositories in your Organization. If you wish to simplify deployment, you can grant this user permission to create repositories. See (Can we use the Bot user to create the ArgoCD repos)[#can-we-use-the-bot-user-to-create-the-argocd-repos].
+    This bot user will need permission to manage a few repositories in your Organization. If you wish to simplify deployment, you can grant this user permission to create repositories. See [Can we use the Bot user to create the ArgoCD repos](#can-we-use-the-bot-user-to-create-the-argocd-repos).
 
     Use this bot user for all access tokens in the remainder of this guide.
   </Step>


### PR DESCRIPTION
## what
fixed wrong synthax for markdown link

## why
link not working

## references
none, multiple other usage of markdown links in the document