### PR TITLE
Workshop #2 time

### DIFF
--- a/docs/jumpstart/kickoff.mdx
+++ b/docs/jumpstart/kickoff.mdx
@@ -82,7 +82,7 @@ This document outlines what to expect from your first call with Cloud Posse. In 
 
       <TabItem label="Option 2" value="option-2">
 
-        > **When:** Wednesdays, 1:00-1:30P PT/ 3:00-3:30P CT/ 4:00-4:30P ET<br/>
+        > **When:** Wednesdays, 2:30-3:00P PT/ 4:30-5:00P CT/ 5:30-6:00P ET<br/>
         > **Where:** Zoom<br/>
         > **Who:** [Essential Support Customers Only](/support/essential)<br/>
 


### PR DESCRIPTION
## what
Changed time for workshop 2 

## why
Starting next week, our Wednesday Customer Workshop will shift to 5:30 PM EDT / 4:30 PM CDT / 2:30 PM PDT (Thursday 7:30 AM in Sydney/Melbourne, 9:30 AM in New Zealand).

This adjustment is designed to better support teams in regions like Australia and New Zealand, while continuing to be accessible to our U.S. customer base (5:30 PM EDT / 4:30 PM CDT / 2:30 PM PDT, same day).

## references
- DEV-3296