### PR TITLE
docs: remove release engineering strategy from quickstart kickoff

### DIFF
--- a/docs/quickstart/kickoff.mdx
+++ b/docs/quickstart/kickoff.mdx
@@ -133,7 +133,6 @@ The following is the agenda for our Kick off call with you. We'll schedule this 
       - [ ] [Decide on CIDR Allocation Strategy](/layers/network/design-decisions/decide-on-cidr-allocation)
       - [ ] [Decide on Service Discovery Domain](/layers/network/design-decisions/decide-on-service-discovery-domain)
       - [ ] [Decide on Vanity Domain](/layers/network/design-decisions/decide-on-vanity-branded-domain)
-      - [ ] [Decide on Release Engineering Strategy](/layers/software-delivery/design-decisions/decide-on-release-engineering-strategy)
 
       <Admonition>
         These are the design decisions you can customize as part of the Quickstart package. All other decisions are pre-made for you, but you’re welcome to review them. If you’d like to make additional changes, [let us know—we’re happy to provide a quote](https://cloudposse.com/meet).


### PR DESCRIPTION
Remove the 'Decide on Release Engineering Strategy' item from the quickstart kickoff design decisions list as it's no longer required for the quickstart process.

This change simplifies the quickstart process by removing a non-essential design decision.

Related: #3264