### PR TITLE
Correct Workshop Time 2

### DIFF
--- a/docs/quickstart/kickoff.mdx
+++ b/docs/quickstart/kickoff.mdx
@@ -86,7 +86,7 @@ The following is the agenda for our Kick off call with you. We'll schedule this 
 
       <TabItem label="Option 2" value="option-2">
 
-        > **When:** Wednesdays, 1:00-1:30P PT/ 3:00-3:30P CT/ 4:00-4:30P ET<br/>
+        > **When:** Wednesdays, 2:30-3:00P PT/ 4:30-5:00P CT/ 5:30-6:00P ET<br/>
         > **Where:** Zoom<br/>
         > **Who:** [Essential Support Customers Only](/support/essential)<br/>
 


### PR DESCRIPTION
## what
- corrected office hour time for quickstart

## why
Starting next week, our Wednesday Customer Workshop will shift to 5:30 PM EDT / 4:30 PM CDT / 2:30 PM PDT (Thursday 7:30 AM in Sydney/Melbourne, 9:30 AM in New Zealand).

This adjustment is designed to better support teams in regions like Australia and New Zealand, while continuing to be accessible to our U.S. customer base (5:30 PM EDT / 4:30 PM CDT / 2:30 PM PDT, same day).

## references
- https://github.com/cloudposse/docs/pull/755
