### PR TITLE
Point Workflows to Copy

### DIFF
--- a/examples/legacy/snippets/stacks/workflows/README.md
+++ b/examples/legacy/snippets/stacks/workflows/README.md
@@ -1,0 +1,69 @@
+# Atmos Workflows
+
+ Atmos Workflows are used to automate deployment or destructions steps within the context of Atmos. Workflows
+combine multiple commands into one executable unit of work.
+
+## Usage
+
+Run any Workflow from the root of the directory by calling `atmos workflow -f filename`. Some workflow require a stack
+parameter, whereas others have the stack predetermined. Add a stack (where applicable) with `-s stack-name`
+
+## Naming Convention
+
+Workflow Jobs can have any name, but in order to maintain consistency, we have chosen to follow a pattern similar to
+Terraform commands.
+
+**Note**: Not all Workflows include each of these commands. These are guidelines for naming any Workflow job.
+
+### `vendor`
+
+Use `vendor` to pull all the latest components for a given layer.
+
+Example
+
+```
+atmos workflow vendor -f baseline
+```
+
+### `init`
+
+Use `atmos workflow init -f {{ filename }}` to run any commands required before deployment.
+
+Example
+
+```
+atmos workflow init -f baseline
+```
+
+### `deploy`
+
+Use `atmos workflow deploy -f {{ filename }}` to deploy all components for a given layer.
+
+```
+atmos workflow deploy -f baseline
+```
+
+Use `atmos workflow deploy/{{ component or group name }} -f {{ filename }}` to deploy a specific component or group of
+components
+
+```
+atmos workflow deploy/vpc -f network
+atmos workflow deploy/tgw -f network
+```
+
+### `all`
+
+Use `atmos workflow all -f {{ filename }}` to run all steps together. This will execute all included jobs in the given
+Workflow in order.
+
+For example,
+
+```
+atmos workflow all -f baseline
+```
+
+
+
+## References
+
+- [Atmos Workflows](https://atmos.tools/core-concepts/workflows/)

--- a/examples/legacy/snippets/stacks/workflows/accounts.yaml
+++ b/examples/legacy/snippets/stacks/workflows/accounts.yaml
@@ -1,0 +1,36 @@
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: workflow deploy/accounts -f accounts
+      - command: workflow deploy/account-settings -f accounts
+
+  deploy/organization:
+    description: | 
+      Deploy the AWS Organization. This is required before finishing the root account requirements.
+    steps:
+      - command: terraform deploy account -target=aws_organizations_organization.this[0] -s core-gbl-root
+      - command: aws ram enable-sharing-with-aws-organization
+        type: shell
+
+  deploy/accounts:
+    description: Deploys all AWS Organization accounts
+    steps:
+      - command: terraform apply account -s core-gbl-root
+      - command: terraform deploy account-map -s core-gbl-root
+
+  deploy/account-settings:
+    description: Apply AWS Account settings for best practices.
+    steps:
+      - command: terraform deploy account-settings -s core-gbl-artifacts
+      - command: terraform deploy account-settings -s core-gbl-audit
+      - command: terraform deploy account-settings -s core-gbl-auto
+      - command: terraform deploy account-settings -s core-gbl-dns
+      - command: terraform deploy account-settings -s core-gbl-identity
+      - command: terraform deploy account-settings -s core-gbl-network
+      - command: terraform deploy account-settings -s core-gbl-root
+      - command: terraform deploy account-settings -s core-gbl-security
+      - command: terraform deploy account-settings -s plat-gbl-dev
+      - command: terraform deploy account-settings -s plat-gbl-prod
+      - command: terraform deploy account-settings -s plat-gbl-sandbox
+      - command: terraform deploy account-settings -s plat-gbl-staging

--- a/examples/legacy/snippets/stacks/workflows/addons.yaml
+++ b/examples/legacy/snippets/stacks/workflows/addons.yaml
@@ -1,0 +1,135 @@
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: workflow vendor -f addons
+      - command: workflow deploy/all -f addons
+
+  vendor:
+    description: Vendor addon components.
+    steps:
+      - command: workflow vendor -f addons/alb
+      - command: workflow vendor -f addons/api-gateway
+      - command: workflow vendor -f addons/cognito
+      - command: workflow vendor -f addons/ec2-instance
+      - command: workflow vendor -f addons/kinesis-stream
+      - command: workflow vendor -f addons/kms
+      - command: workflow vendor -f addons/lambda
+      - command: workflow vendor -f addons/memorydb
+      - command: workflow vendor -f addons/s3-bucket
+      - command: workflow vendor -f addons/ses
+      - command: workflow vendor -f addons/sns-topic
+      - command: workflow vendor -f addons/spa-s3-cloudfront
+      - command: workflow vendor -f addons/sqs-queue
+      - command: workflow vendor -f addons/ssm-parameters
+      - command: workflow vendor -f addons/waf
+
+  deploy/all:
+    description: run all deploy workflows
+    steps:
+      - command: workflow deploy/alb -f addons
+      - command: workflow deploy/api-gateway -f addons
+      - command: workflow deploy/cognito -f addons
+      - command: workflow deploy/ec2-instance -f addons
+      - command: workflow deploy/kinesis-stream -f addons
+      - command: workflow deploy/kms -f addons
+      - command: workflow deploy/lambda -f addons
+      - command: workflow deploy/memorydb -f addons
+      - command: workflow deploy/s3-bucket -f addons
+      - command: workflow deploy/ses -f addons
+      - command: workflow deploy/sns-topic -f addons
+      - command: workflow deploy/spa-s3-cloudfront -f addons
+      - command: workflow deploy/sqs-queue -f addons
+      - command: workflow deploy/ssm-parameters -f addons
+      - command: workflow deploy/waf -f addons
+    
+  deploy/alb:
+    description: >-
+      Deploy Alb Component.
+      Please modify the stacks/workflows/addons/alb.yaml to customize
+    steps:
+      - command: workflow all -f addons/alb
+  deploy/api-gateway:
+    description: >-
+      Deploy Api-Gateway Component.
+      Please modify the stacks/workflows/addons/api-gateway.yaml to customize
+    steps:
+      - command: workflow all -f addons/api-gateway
+  deploy/cognito:
+    description: >-
+      Deploy Cognito Component.
+      Please modify the stacks/workflows/addons/cognito.yaml to customize
+    steps:
+      - command: workflow all -f addons/cognito
+  deploy/ec2-instance:
+    description: >-
+      Deploy Ec2-Instance Component.
+      Please modify the stacks/workflows/addons/ec2-instance.yaml to customize
+    steps:
+      - command: workflow all -f addons/ec2-instance
+  deploy/kinesis-stream:
+    description: >-
+      Deploy Kinesis-Stream Component.
+      Please modify the stacks/workflows/addons/kinesis-stream.yaml to customize
+    steps:
+      - command: workflow all -f addons/kinesis-stream
+  deploy/kms:
+    description: >-
+      Deploy Kms Component.
+      Please modify the stacks/workflows/addons/kms.yaml to customize
+    steps:
+      - command: workflow all -f addons/kms
+  deploy/lambda:
+    description: >-
+      Deploy Lambda Component.
+      Please modify the stacks/workflows/addons/lambda.yaml to customize
+    steps:
+      - command: workflow all -f addons/lambda
+  deploy/memorydb:
+    description: >-
+      Deploy Memorydb Component.
+      Please modify the stacks/workflows/addons/memorydb.yaml to customize
+    steps:
+      - command: workflow all -f addons/memorydb
+  deploy/s3-bucket:
+    description: >-
+      Deploy S3-Bucket Component.
+      Please modify the stacks/workflows/addons/s3-bucket.yaml to customize
+    steps:
+      - command: workflow all -f addons/s3-bucket
+  deploy/ses:
+    description: >-
+      Deploy Ses Component.
+      Please modify the stacks/workflows/addons/ses.yaml to customize
+    steps:
+      - command: workflow all -f addons/ses
+  deploy/sns-topic:
+    description: >-
+      Deploy Sns-Topic Component.
+      Please modify the stacks/workflows/addons/sns-topic.yaml to customize
+    steps:
+      - command: workflow all -f addons/sns-topic
+  deploy/spa-s3-cloudfront:
+    description: >-
+      Deploy Spa-S3-Cloudfront Component.
+      Please modify the stacks/workflows/addons/spa-s3-cloudfront.yaml to customize
+    steps:
+      - command: workflow all -f addons/spa-s3-cloudfront
+  deploy/sqs-queue:
+    description: >-
+      Deploy Sqs-Queue Component.
+      Please modify the stacks/workflows/addons/sqs-queue.yaml to customize
+    steps:
+      - command: workflow all -f addons/sqs-queue
+  deploy/ssm-parameters:
+    description: >-
+      Deploy Ssm-Parameters Component.
+      Please modify the stacks/workflows/addons/ssm-parameters.yaml to customize
+    steps:
+      - command: workflow all -f addons/ssm-parameters
+  deploy/waf:
+    description: >-
+      Deploy Waf Component.
+      Please modify the stacks/workflows/addons/waf.yaml to customize
+    steps:
+      - command: workflow all -f addons/waf

--- a/examples/legacy/snippets/stacks/workflows/addons/alb.yaml
+++ b/examples/legacy/snippets/stacks/workflows/addons/alb.yaml
@@ -1,0 +1,10 @@
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: terraform deploy alb --stack plat-use1-sandbox
+
+  vendor:
+    description: vendor all components required for this addon
+    steps:
+      - command: vendor pull --component alb

--- a/examples/legacy/snippets/stacks/workflows/addons/api-gateway.yaml
+++ b/examples/legacy/snippets/stacks/workflows/addons/api-gateway.yaml
@@ -1,0 +1,12 @@
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: terraform deploy api-gateway/account-settings --stack plat-use1-sandbox
+      - command: terraform deploy api-gateway/rest-api --stack plat-use1-sandbox
+
+  vendor:
+    description: vendor all components required for this addon
+    steps:
+      - command: vendor pull --component api-gateway/account-settings
+      - command: vendor pull --component api-gateway/rest-api

--- a/examples/legacy/snippets/stacks/workflows/addons/cognito.yaml
+++ b/examples/legacy/snippets/stacks/workflows/addons/cognito.yaml
@@ -1,0 +1,10 @@
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: terraform deploy cognito --stack plat-use1-sandbox
+
+  vendor:
+    description: vendor all components required for this addon
+    steps:
+      - command: vendor pull --component cognito

--- a/examples/legacy/snippets/stacks/workflows/addons/ec2-instance.yaml
+++ b/examples/legacy/snippets/stacks/workflows/addons/ec2-instance.yaml
@@ -1,0 +1,10 @@
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: terraform deploy ec2-instance --stack plat-use1-sandbox
+
+  vendor:
+    description: vendor all components required for this addon
+    steps:
+      - command: vendor pull --component ec2-instance

--- a/examples/legacy/snippets/stacks/workflows/addons/kinesis-stream.yaml
+++ b/examples/legacy/snippets/stacks/workflows/addons/kinesis-stream.yaml
@@ -1,0 +1,10 @@
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: terraform deploy kinesis-stream/example --stack plat-use1-sandbox
+
+  vendor:
+    description: vendor all components required for this addon
+    steps:
+      - command: vendor pull --component kinesis-stream

--- a/examples/legacy/snippets/stacks/workflows/addons/kms.yaml
+++ b/examples/legacy/snippets/stacks/workflows/addons/kms.yaml
@@ -1,0 +1,10 @@
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: terraform deploy kms --stack plat-use1-sandbox
+
+  vendor:
+    description: vendor all components required for this addon
+    steps:
+      - command: vendor pull --component kms

--- a/examples/legacy/snippets/stacks/workflows/addons/lambda.yaml
+++ b/examples/legacy/snippets/stacks/workflows/addons/lambda.yaml
@@ -1,0 +1,10 @@
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: terraform deploy lambda/hello-world-py --stack plat-use1-sandbox
+
+  vendor:
+    description: vendor all components required for this addon
+    steps:
+      - command: vendor pull --component lambda

--- a/examples/legacy/snippets/stacks/workflows/addons/memorydb.yaml
+++ b/examples/legacy/snippets/stacks/workflows/addons/memorydb.yaml
@@ -1,0 +1,10 @@
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: terraform deploy memorydb --stack plat-use1-sandbox
+
+  vendor:
+    description: vendor all components required for this addon
+    steps:
+      - command: vendor pull --component memorydb

--- a/examples/legacy/snippets/stacks/workflows/addons/s3-bucket.yaml
+++ b/examples/legacy/snippets/stacks/workflows/addons/s3-bucket.yaml
@@ -1,0 +1,10 @@
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: terraform deploy s3-bucket/sample --stack plat-use1-sandbox
+
+  vendor:
+    description: vendor all components required for this addon
+    steps:
+      - command: vendor pull --component s3-bucket

--- a/examples/legacy/snippets/stacks/workflows/addons/ses.yaml
+++ b/examples/legacy/snippets/stacks/workflows/addons/ses.yaml
@@ -1,0 +1,10 @@
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: terraform deploy ses --stack plat-use1-sandbox
+
+  vendor:
+    description: vendor all components required for this addon
+    steps:
+      - command: vendor pull --component ses

--- a/examples/legacy/snippets/stacks/workflows/addons/sns-topic.yaml
+++ b/examples/legacy/snippets/stacks/workflows/addons/sns-topic.yaml
@@ -1,0 +1,10 @@
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: terraform deploy sns-topic-example --stack plat-use1-sandbox
+
+  vendor:
+    description: vendor all components required for this addon
+    steps:
+      - command: vendor pull --component sns-topic

--- a/examples/legacy/snippets/stacks/workflows/addons/spa-s3-cloudfront.yaml
+++ b/examples/legacy/snippets/stacks/workflows/addons/spa-s3-cloudfront.yaml
@@ -1,0 +1,22 @@
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: atmos workflow deploy -f addons/spa-s3-cloudfront
+      - command: atmos workflow upload -f addons/spa-s3-cloudfront
+
+  vendor:
+    description: vendor all components required for this addon
+    steps:
+      - command: vendor pull --component spa-s3-cloudfront
+
+  deploy:
+    description: Deploy the component
+    steps:
+      - command: terraform deploy spa-s3-cloudfront/example-site --stack plat-use1-sandbox
+
+  upload:
+    description: Upload example content
+    steps:
+      - type: shell
+        command: AWS_PROFILE=acme-plat-gbl-sandbox-admin aws s3 sync components/terraform/spa-s3-cloudfront/example-site s3://acme-plat-use1-sandbox-example-site-origin

--- a/examples/legacy/snippets/stacks/workflows/addons/sqs-queue.yaml
+++ b/examples/legacy/snippets/stacks/workflows/addons/sqs-queue.yaml
@@ -1,0 +1,10 @@
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: terraform deploy sqs-queue --stack plat-use1-sandbox
+
+  vendor:
+    description: vendor all components required for this addon
+    steps:
+      - command: vendor pull --component sqs-queue

--- a/examples/legacy/snippets/stacks/workflows/addons/ssm-parameters.yaml
+++ b/examples/legacy/snippets/stacks/workflows/addons/ssm-parameters.yaml
@@ -1,0 +1,10 @@
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: terraform deploy ssm-parameters --stack plat-use1-sandbox
+
+  vendor:
+    description: vendor all components required for this addon
+    steps:
+      - command: vendor pull --component ssm-parameters

--- a/examples/legacy/snippets/stacks/workflows/addons/waf.yaml
+++ b/examples/legacy/snippets/stacks/workflows/addons/waf.yaml
@@ -1,0 +1,10 @@
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: terraform deploy waf --stack plat-use1-sandbox
+
+  vendor:
+    description: vendor all components required for this addon
+    steps:
+      - command: vendor pull --component waf

--- a/examples/legacy/snippets/stacks/workflows/alerting.yaml
+++ b/examples/legacy/snippets/stacks/workflows/alerting.yaml
@@ -1,0 +1,46 @@
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: workflow init -f alerting
+      - command: workflow vendor -f alerting
+      - command: workflow deploy -f alerting
+
+
+  init:
+    description: Prompt to collect the OpsGenie API Key and write it to AWS SSM
+    steps:
+      - type: shell
+        command: |-
+          if [ $( AWS_PROFILE=acme-core-gbl-auto-admin chamber read opsgenie opsgenie_api_key ) ]; then
+            echo "Found OpsGenie API Key, skipping init..."
+            exit 0
+          fi
+
+          echo "Please enter an OpsGenie API Key"
+          stty -echo
+          read -p "API Key: " -r API_KEY
+          stty echo
+          if [ -z "$API_KEY" ]
+          then
+              echo 'Inputs cannot be blank, please try again!'
+              exit 0
+          fi
+          if ! [[ "$API_KEY" =~ "^[a-zA-Z0-9-]{36}$" ]]
+          then
+              echo "Invalid API Key"
+              echo "HINT: The API key ID is displayed as a lower-case, 36-character alphanumeric value."
+              exit 0
+          fi
+          AWS_PROFILE=acme-core-gbl-auto-admin chamber write opsgenie opsgenie_api_key "$API_KEY"
+
+  vendor:
+    description: vendor dependencies
+    steps:
+      - command: vendor pull --component opsgenie-team
+
+  deploy:
+    description: opsgenie
+    steps:
+      - command: terraform deploy opsgenie-team/app-team-1 -s core-gbl-auto
+      - command: terraform deploy opsgenie-team/sre -s core-gbl-auto

--- a/examples/legacy/snippets/stacks/workflows/app-on-ecs.yaml
+++ b/examples/legacy/snippets/stacks/workflows/app-on-ecs.yaml
@@ -1,0 +1,22 @@
+workflows:
+  all:
+    steps:
+      - command: workflow verify/github-oidc-providers -f app-on-ecs
+      - command: workflow deploy/app-on-ecs -f app-on-ecs
+
+  verify/github-oidc-providers:
+    description: |
+      This workflow ensures all Github OIDC Provider Configuration deployed.
+    steps:
+      - command: workflow deploy/github-oidc-provider -f github
+
+  deploy/app-on-ecs:
+    description: |
+      This workflow deploys `app-on-ecs` stacks
+    steps:
+      - command: terraform deploy ecs-services/example-app-on-ecs -s plat-use1-sandbox
+      - command: terraform deploy ecs-services/example-app-on-ecs/dev -s plat-use1-dev
+      - command: terraform deploy ecs-services/example-app-on-ecs/qa1 -s plat-use1-dev
+      - command: terraform deploy ecs-services/example-app-on-ecs/qa2 -s plat-use1-dev
+      - command: terraform deploy ecs-services/example-app-on-ecs -s plat-use1-staging
+      - command: terraform deploy ecs-services/example-app-on-ecs -s plat-use1-prod

--- a/examples/legacy/snippets/stacks/workflows/argocd.yaml
+++ b/examples/legacy/snippets/stacks/workflows/argocd.yaml
@@ -1,0 +1,283 @@
+workflows:
+  vendor:
+    description: |
+      This workflow vendors all ArgoCD related components to the latest provided version
+    steps:
+      - command: vendor pull --component argocd-repo
+      - command: vendor pull --component sso-saml-provider
+      - command: vendor pull --component eks/argocd
+
+  deploy/argocd:
+    description: |
+      This workflow deploys ArgoCD
+    steps:
+      - command: terraform deploy eks/argocd -s plat-use1-dev
+      - command: terraform deploy eks/argocd -s plat-use1-staging
+      - command: terraform deploy eks/argocd -s plat-use1-prod
+
+  deploy/argocd-repos:
+    description: |
+      This workflow deploys ArgoCD repos
+    steps:
+      - command: terraform deploy argocd-deploy-non-prod -s core-gbl-auto
+      - command: terraform deploy argocd-deploy-prod -s core-gbl-auto
+
+  deploy/iam-identity-center-app/dev:
+    description: Prompt for uploading SSO SAML configs to AWS SSM for dev
+    steps:
+      - type: shell
+        command: |-
+          echo "Please create a new IAM Identity Center SAML App for prod"
+          echo "Use https://argocd.use1.dev.plat.acme-svc.com/api/dex/callback"
+
+          echo "Please enter the IAM Identity Center SAML issuer URL"
+          read -p "IAM Identity Center Issuer URL: " -r SSO_ISSUER
+          if [ -z "SSO_ISSUER" ]
+          then
+              echo 'Inputs cannot be blank please try again!'
+              exit 0
+          fi
+
+          echo "Please download the IAM Identity Center Certificate and enter the path here"
+          DEFAULT_SSO_CA_PATH="/localhost/Downloads/AWS_SSO_for_Custom SAML 2.0 application_certificate.pem"
+          read -p "IAM Identity Center Certificate path [${DEFAULT_SSO_CA_PATH}]: " -r SSO_CA_PATH
+          SSO_CA_PATH=${SSO_CA_PATH:-$DEFAULT_SSO_CA_PATH}
+          if [ -z "SSO_CA_PATH" ]
+          then
+              echo 'Inputs cannot be blank please try again!'
+              exit 0
+          fi
+
+          prefix="-----BEGIN CERTIFICATE-----"
+          suffix="-----END CERTIFICATE-----"
+          FULL_SSO_CA=$(cat "$SSO_CA_PATH" | tr -d '\n')
+          SSO_CA=${FULL_SSO_CA#"$prefix"}
+          SSO_CA=${SSO_CA%"$suffix"}
+
+          AWS_PROFILE=acme-plat-gbl-dev-admin chamber write argocd/saml issuer $SSO_ISSUER
+          AWS_PROFILE=acme-plat-gbl-dev-admin chamber write argocd/saml url $SSO_ISSUER
+          AWS_PROFILE=acme-plat-gbl-dev-admin chamber write argocd/saml ca $SSO_CA
+
+          echo "Uploaded to SSM."
+          echo "Don't forget to set attribute mappings and assign groups to the new app!"
+          read -p "Continue with component deployment? (yes/no) " -r CONTINUE
+          if [[ "$CONTINUE" != "yes" ]]
+          then
+            echo "Exiting."
+            exit 0
+          fi
+      - command: terraform deploy sso-saml-provider -s plat-use1-dev
+
+  deploy/iam-identity-center-app/staging:
+    description: Prompt for uploading SSO SAML configs to AWS SSM for staging
+    steps:
+      - type: shell
+        command: |-
+          echo "Please create a new IAM Identity Center SAML App for prod"
+          echo "Use https://argocd.use1.staging.plat.acme-svc.com/api/dex/callback"
+
+          echo "Please enter the IAM Identity Center SAML issuer URL"
+          read -p "IAM Identity Center Issuer URL: " -r SSO_ISSUER
+          if [ -z "SSO_ISSUER" ]
+          then
+              echo 'Inputs cannot be blank please try again!'
+              exit 0
+          fi
+
+          echo "Please download the IAM Identity Center Certificate and enter the path here"
+          DEFAULT_SSO_CA_PATH="/localhost/Downloads/AWS_SSO_for_Custom SAML 2.0 application_certificate.pem"
+          read -p "IAM Identity Center Certificate path [${DEFAULT_SSO_CA_PATH}]: " -r SSO_CA_PATH
+          SSO_CA_PATH=${SSO_CA_PATH:-$DEFAULT_SSO_CA_PATH}
+          if [ -z "SSO_CA_PATH" ]
+          then
+              echo 'Inputs cannot be blank please try again!'
+              exit 0
+          fi
+
+          prefix="-----BEGIN CERTIFICATE-----"
+          suffix="-----END CERTIFICATE-----"
+          FULL_SSO_CA=$(cat "$SSO_CA_PATH" | tr -d '\n')
+          SSO_CA=${FULL_SSO_CA#"$prefix"}
+          SSO_CA=${SSO_CA%"$suffix"}
+
+          AWS_PROFILE=acme-plat-gbl-staging-admin chamber write argocd/saml issuer $SSO_ISSUER
+          AWS_PROFILE=acme-plat-gbl-staging-admin chamber write argocd/saml url $SSO_ISSUER
+          AWS_PROFILE=acme-plat-gbl-staging-admin chamber write argocd/saml ca $SSO_CA
+
+          echo "Uploaded to SSM."
+          echo "Don't forget to set attribute mappings and assign groups to the new app!"
+          read -p "Continue with component deployment? (yes/no) " -r CONTINUE
+          if [[ "$CONTINUE" != "yes" ]]
+          then
+            echo "Exiting."
+            exit 0
+          fi
+      - command: terraform deploy sso-saml-provider -s plat-use1-staging
+
+  deploy/iam-identity-center-app/prod:
+    description: Prompt for uploading SSO SAML configs to AWS SSM for prod
+    steps:
+      - type: shell
+        command: |-
+          echo "Please create a new IAM Identity Center SAML App for prod"
+          echo "Use https://argocd.use1.prod.plat.acme-svc.com/api/dex/callback"
+
+          echo "Please enter the IAM Identity Center SAML issuer URL"
+          read -p "IAM Identity Center Issuer URL: " -r SSO_ISSUER
+          if [ -z "SSO_ISSUER" ]
+          then
+              echo 'Inputs cannot be blank please try again!'
+              exit 0
+          fi
+
+          echo "Please download the IAM Identity Center Certificate and enter the path here"
+          DEFAULT_SSO_CA_PATH="/localhost/Downloads/AWS_SSO_for_Custom SAML 2.0 application_certificate.pem"
+          read -p "IAM Identity Center Certificate path [${DEFAULT_SSO_CA_PATH}]: " -r SSO_CA_PATH
+          SSO_CA_PATH=${SSO_CA_PATH:-$DEFAULT_SSO_CA_PATH}
+          if [ -z "SSO_CA_PATH" ]
+          then
+              echo 'Inputs cannot be blank please try again!'
+              exit 0
+          fi
+
+          prefix="-----BEGIN CERTIFICATE-----"
+          suffix="-----END CERTIFICATE-----"
+          FULL_SSO_CA=$(cat "$SSO_CA_PATH" | tr -d '\n')
+          SSO_CA=${FULL_SSO_CA#"$prefix"}
+          SSO_CA=${SSO_CA%"$suffix"}
+
+          AWS_PROFILE=acme-plat-gbl-prod-admin chamber write argocd/saml issuer $SSO_ISSUER
+          AWS_PROFILE=acme-plat-gbl-prod-admin chamber write argocd/saml url $SSO_ISSUER
+          AWS_PROFILE=acme-plat-gbl-prod-admin chamber write argocd/saml ca $SSO_CA
+
+          echo "Uploaded to SSM."
+          echo "Don't forget to set attribute mappings and assign groups to the new app!"
+          read -p "Continue with component deployment? (yes/no) " -r CONTINUE
+          if [[ "$CONTINUE" != "yes" ]]
+          then
+            echo "Exiting."
+            exit 0
+          fi
+      - command: terraform deploy sso-saml-provider -s plat-use1-prod
+
+  deploy/terraform-argocdrepo-pat:
+    description: Prompt for creating the argocd/terraform/argocd-repo GitHub PAT
+    steps:
+      - type: shell
+        command: |-
+          echo "Please create a fine-grained GitHub PAT"
+          echo "Scope: acme/argocd-deploy-non-prod and acme/argocd-deploy-prod"
+          echo "Permissions: (Repository) Administration: Read and write, Contents: Read and write, Metadata: Read-only. (Organization) Members: Read-only"
+          echo "Follow this manual to create PAT https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token"
+          echo "Upload the fine-grained GitHub PAT to AWS SSM"
+          stty -echo
+          read -p "GitHub PAT (text will be hidden): " -r GITHUB_PAT
+          stty echo
+          if [ -z "GITHUB_PAT" ]
+          then
+              echo 'Inputs cannot be blank please try again!'
+              exit 0
+          fi
+          AWS_PROFILE=acme-core-gbl-auto-admin chamber write argocd/github api_key $GITHUB_PAT
+
+  deploy/terraform-webhooks-nonprod-pat:
+    description: Prompt for creating the argocd/terraform-webhooks/nonprod GitHub PAT
+    steps:
+      - type: shell
+        command: |-
+          echo "Please create a fine-grained GitHub PAT"
+          echo "Scope: acme/argocd-deploy-non-prod"
+          echo "Permissions: (Repository) Webhooks: Read and write, Metadata: Read-only"
+          echo "Follow this manual to create PAT https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token"
+          echo "Upload the fine-grained GitHub PAT to AWS SSM"
+          stty -echo
+          read -p "GitHub PAT (text will be hidden): " -r GITHUB_PAT
+          stty echo
+          if [ -z "GITHUB_PAT" ]
+          then
+              echo 'Inputs cannot be blank please try again!'
+              exit 0
+          fi
+          AWS_PROFILE=acme-plat-gbl-dev-admin chamber write argocd/github api_key $GITHUB_PAT
+          AWS_PROFILE=acme-plat-gbl-staging-admin chamber write argocd/github api_key $GITHUB_PAT
+
+  deploy/terraform-webhooks-prod-pat:
+    description: Prompt for creating the argocd/terraform-webhooks/prod GitHub PAT
+    steps:
+      - type: shell
+        command: |-
+          echo "Please create a fine-grained GitHub PAT"
+          echo "Scope: acme/argocd-deploy-prod"
+          echo "Permissions: (Repository) Webhooks: Read and write, Metadata: Read-only"
+          echo "Follow this manual to create PAT https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token"
+          echo "Upload the fine-grained GitHub PAT to AWS SSM"
+          stty -echo
+          read -p "GitHub PAT (text will be hidden): " -r GITHUB_PAT
+          stty echo
+          if [ -z "GITHUB_PAT" ]
+          then
+              echo 'Inputs cannot be blank please try again!'
+              exit 0
+          fi
+          AWS_PROFILE=acme-plat-gbl-prod-admin chamber write argocd/github api_key $GITHUB_PAT
+
+  deploy/app-notifications-pat:
+    description: Prompt for creating the ARGOCD_APP_NOTIFICATIONS GitHub PAT
+    steps:
+      - type: shell
+        command: |-
+          echo "Please create a classic GitHub PAT"
+          echo "Scope: n/a"
+          echo "Permissions: repo:status"
+          echo "Follow this manual to create PAT https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token"
+          echo "Upload the classic GitHub PAT to AWS SSM"
+          stty -echo
+          read -p "GitHub PAT (text will be hidden): " -r GITHUB_PAT
+          stty echo
+          if [ -z "GITHUB_PAT" ]
+          then
+              echo 'Inputs cannot be blank please try again!'
+              exit 0
+          fi
+          AWS_PROFILE=acme-plat-gbl-dev-admin chamber write argocd/notifications/notifiers/common github-token $GITHUB_PAT
+          AWS_PROFILE=acme-plat-gbl-staging-admin chamber write argocd/notifications/notifiers/common github-token $GITHUB_PAT
+          AWS_PROFILE=acme-plat-gbl-prod-admin chamber write argocd/notifications/notifiers/common github-token $GITHUB_PAT
+
+  deploy/github-nonprod-pat:
+    description: Prompt for creating the argocd/github/nonprod GitHub PAT
+    steps:
+      - type: shell
+        command: |-
+          echo "Please create a fine-grained GitHub PAT"
+          echo "Scope: acme/argocd-deploy-non-prod and acme/infra-acme"
+          echo "Permissions: (Repository) Contents: Read and write, Metadata: Read-only"
+          echo "Follow this manual to create PAT https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token"
+          echo "Please upload this PAT to 1Password"
+
+  deploy/github-prod-pat:
+    description: Prompt for creating the argocd/github/prod GitHub PAT
+    steps:
+      - type: shell
+        command: |-
+          echo "Please create a fine-grained GitHub PAT"
+          echo "Scope: acme/argocd-deploy-prod and acme/infra-acme"
+          echo "Permissions: (Repository) Contents: Read and write, Metadata: Read-only"
+          echo "Follow this manual to create PAT https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token"
+          echo "Please upload this PAT to 1Password"
+
+  migrate_less_1_305:
+    description: |
+      This workflow migrates ArgoCD to `0.0.0`
+    steps:
+      - type: shell
+        command: |-
+          AWS_PROFILE=acme-plat-gbl-dev-admin chamber read -q argocd/notifications/notifiers/service_webhook_github-commit-status github-token | AWS_PROFILE=acme-plat-gbl-dev-admin  chamber write argocd/notifications/notifiers/common github-token
+          AWS_PROFILE=acme-plat-gbl-dev-admin chamber delete argocd/notifications/notifiers/service_webhook_github-commit-status github-token
+          AWS_PROFILE=acme-plat-gbl-dev-admin chamber delete argocd/notifications/notifiers/service_githubAWS_PROFILE=acme-plat-gbl-staging-admin chamber read -q argocd/notifications/notifiers/service_webhook_github-commit-status github-token | AWS_PROFILE=acme-plat-gbl-staging-admin  chamber write argocd/notifications/notifiers/common github-token
+          AWS_PROFILE=acme-plat-gbl-staging-admin chamber delete argocd/notifications/notifiers/service_webhook_github-commit-status github-token
+          AWS_PROFILE=acme-plat-gbl-staging-admin chamber delete argocd/notifications/notifiers/service_githubAWS_PROFILE=acme-plat-gbl-prod-admin chamber read -q argocd/notifications/notifiers/service_webhook_github-commit-status github-token | AWS_PROFILE=acme-plat-gbl-prod-admin  chamber write argocd/notifications/notifiers/common github-token
+          AWS_PROFILE=acme-plat-gbl-prod-admin chamber delete argocd/notifications/notifiers/service_webhook_github-commit-status github-token
+          AWS_PROFILE=acme-plat-gbl-prod-admin chamber delete argocd/notifications/notifiers/service_github
+      - command: workflow deploy/github-webhook-pat -f argocd
+      - command: workflow deploy/argocd -f argocd
+      - command: workflow deploy/argocd-repos -f argocd

--- a/examples/legacy/snippets/stacks/workflows/baseline.yaml
+++ b/examples/legacy/snippets/stacks/workflows/baseline.yaml
@@ -1,0 +1,49 @@
+
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: workflow vendor -f baseline
+      - command: workflow init/tfstate -f baseline
+      - command: workflow deploy/tfstate -f baseline
+      - command: workflow deploy/cloudtrail -f baseline
+      - command: workflow deploy/ecr -f baseline
+
+  vendor:
+    description: Vendor baseline layer components.
+    steps:
+      - command: vendor pull --component account
+      - command: vendor pull --component account-map
+      - command: vendor pull --component account-quotas
+      - command: vendor pull --component account-settings
+      - command: vendor pull --component cloudtrail
+      - command: vendor pull --component cloudtrail-bucket
+      - command: vendor pull --component ecr
+      - command: vendor pull --component tfstate-backend
+
+  init/tfstate:
+    description: Provision Terraform State Backend for initial deployment.
+    steps:
+      - command: terraform deploy tfstate-backend -var=access_roles_enabled=false --stack core-use1-root --auto-generate-backend-file=false
+      - command: until aws s3 ls acme-core-use1-root-tfstate; do sleep 5; done
+        type: shell
+      - command: terraform deploy tfstate-backend -var=access_roles_enabled=false --stack core-use1-root --init-run-reconfigure=false
+
+  deploy/tfstate:
+    description: >-
+      Deploy Terraform State Backend.
+
+      Finalize Terraform State Backend access, which requires AWS Teams to be deployed first.
+    steps:
+      - command: terraform deploy tfstate-backend --stack core-use1-root
+
+  deploy/cloudtrail:
+    description: Start AWS Cloudtrail in audit and root accounts to track changes across the org.
+    steps:
+      - command: terraform deploy cloudtrail-bucket -s core-use1-audit
+      - command: terraform deploy cloudtrail -s core-gbl-root
+
+  deploy/ecr:
+    description: Deploy ECR in the artifacts account to use as our container registry
+    steps:
+      - command: terraform deploy ecr -s core-use1-artifacts

--- a/examples/legacy/snippets/stacks/workflows/compliance.yaml
+++ b/examples/legacy/snippets/stacks/workflows/compliance.yaml
@@ -1,0 +1,288 @@
+workflows:
+  vendor:
+    description: Vendor compliance layer components and scripts.
+    steps:
+      - command: vendor pull --component config-bucket
+      - command: vendor pull --component cloudtrail-bucket
+      - command: vendor pull --component aws-config
+      - command: vendor pull --component security-hub
+      - command: vendor pull --component guardduty
+      - command: vendor pull --component s3-bucket
+      - command: vendor pull --component route53-resolver-dns-firewall
+      - command: vendor pull --component aws-shield
+      - command: vendor pull --component aws-inspector2
+
+  deploy/aws-config/global-collector:
+    description: Deploy AWS Config into main global collector account
+    steps:
+      # Note that central region 'use1' and central account 'security' should be the first one created
+      - command: terraform deploy aws-config-use1 -s core-use1-security
+      - command: terraform deploy aws-config-use2 -s core-use2-security
+      - command: terraform deploy aws-config-usw1 -s core-usw1-security
+      - command: terraform deploy aws-config-usw2 -s core-usw2-security
+      - command: terraform deploy aws-config-aps1 -s core-aps1-security
+      - command: terraform deploy aws-config-apne3 -s core-apne3-security
+      - command: terraform deploy aws-config-apne2 -s core-apne2-security
+      - command: terraform deploy aws-config-apne1 -s core-apne1-security
+      - command: terraform deploy aws-config-apse1 -s core-apse1-security
+      - command: terraform deploy aws-config-apse2 -s core-apse2-security
+      - command: terraform deploy aws-config-cac1 -s core-cac1-security
+      - command: terraform deploy aws-config-euc1 -s core-euc1-security
+      - command: terraform deploy aws-config-euw1 -s core-euw1-security
+      - command: terraform deploy aws-config-euw2 -s core-euw2-security
+      - command: terraform deploy aws-config-euw3 -s core-euw3-security
+      - command: terraform deploy aws-config-eun1 -s core-eun1-security
+      - command: terraform deploy aws-config-sae1 -s core-sae1-security
+
+  deploy/aws-config/superadmin:
+    description: Deploy AWS Config into accounts that require SuperAdmin to apply
+    steps:
+      - command: terraform deploy aws-config-use1 -s core-use1-identity
+      - command: terraform deploy aws-config-use1 -s core-use1-root
+      - command: terraform deploy aws-config-use2 -s core-use2-identity
+      - command: terraform deploy aws-config-use2 -s core-use2-root
+      - command: terraform deploy aws-config-usw1 -s core-usw1-identity
+      - command: terraform deploy aws-config-usw1 -s core-usw1-root
+      - command: terraform deploy aws-config-usw2 -s core-usw2-identity
+      - command: terraform deploy aws-config-usw2 -s core-usw2-root
+      - command: terraform deploy aws-config-aps1 -s core-aps1-identity
+      - command: terraform deploy aws-config-aps1 -s core-aps1-root
+      - command: terraform deploy aws-config-apne3 -s core-apne3-identity
+      - command: terraform deploy aws-config-apne3 -s core-apne3-root
+      - command: terraform deploy aws-config-apne2 -s core-apne2-identity
+      - command: terraform deploy aws-config-apne2 -s core-apne2-root
+      - command: terraform deploy aws-config-apne1 -s core-apne1-identity
+      - command: terraform deploy aws-config-apne1 -s core-apne1-root
+      - command: terraform deploy aws-config-apse1 -s core-apse1-identity
+      - command: terraform deploy aws-config-apse1 -s core-apse1-root
+      - command: terraform deploy aws-config-apse2 -s core-apse2-identity
+      - command: terraform deploy aws-config-apse2 -s core-apse2-root
+      - command: terraform deploy aws-config-cac1 -s core-cac1-identity
+      - command: terraform deploy aws-config-cac1 -s core-cac1-root
+      - command: terraform deploy aws-config-euc1 -s core-euc1-identity
+      - command: terraform deploy aws-config-euc1 -s core-euc1-root
+      - command: terraform deploy aws-config-euw1 -s core-euw1-identity
+      - command: terraform deploy aws-config-euw1 -s core-euw1-root
+      - command: terraform deploy aws-config-euw2 -s core-euw2-identity
+      - command: terraform deploy aws-config-euw2 -s core-euw2-root
+      - command: terraform deploy aws-config-euw3 -s core-euw3-identity
+      - command: terraform deploy aws-config-euw3 -s core-euw3-root
+      - command: terraform deploy aws-config-eun1 -s core-eun1-identity
+      - command: terraform deploy aws-config-eun1 -s core-eun1-root
+      - command: terraform deploy aws-config-sae1 -s core-sae1-identity
+      - command: terraform deploy aws-config-sae1 -s core-sae1-root
+
+  deploy/security-hub/step1:
+    description: Deploy Security Hub to Delegated Administrator account (core-security)
+    steps:
+      - command: terraform deploy security-hub/delegated-administrator/use1 -s core-use1-security
+      - command: terraform deploy security-hub/delegated-administrator/use2 -s core-use2-security
+      - command: terraform deploy security-hub/delegated-administrator/usw1 -s core-usw1-security
+      - command: terraform deploy security-hub/delegated-administrator/usw2 -s core-usw2-security
+      - command: terraform deploy security-hub/delegated-administrator/aps1 -s core-aps1-security
+      - command: terraform deploy security-hub/delegated-administrator/apne3 -s core-apne3-security
+      - command: terraform deploy security-hub/delegated-administrator/apne2 -s core-apne2-security
+      - command: terraform deploy security-hub/delegated-administrator/apne1 -s core-apne1-security
+      - command: terraform deploy security-hub/delegated-administrator/apse1 -s core-apse1-security
+      - command: terraform deploy security-hub/delegated-administrator/apse2 -s core-apse2-security
+      - command: terraform deploy security-hub/delegated-administrator/cac1 -s core-cac1-security
+      - command: terraform deploy security-hub/delegated-administrator/euc1 -s core-euc1-security
+      - command: terraform deploy security-hub/delegated-administrator/euw1 -s core-euw1-security
+      - command: terraform deploy security-hub/delegated-administrator/euw2 -s core-euw2-security
+      - command: terraform deploy security-hub/delegated-administrator/euw3 -s core-euw3-security
+      - command: terraform deploy security-hub/delegated-administrator/eun1 -s core-eun1-security
+      - command: terraform deploy security-hub/delegated-administrator/sae1 -s core-sae1-security
+
+  deploy/security-hub/step2:
+    description: Deploy Security Hub to AWS Organizations Management Account (core-root). You must be SuperAdmin to run this workflow.
+    steps:
+      - command: terraform deploy security-hub/root/use1 -s core-use1-root
+      - command: terraform deploy security-hub/root/use2 -s core-use2-root
+      - command: terraform deploy security-hub/root/usw1 -s core-usw1-root
+      - command: terraform deploy security-hub/root/usw2 -s core-usw2-root
+      - command: terraform deploy security-hub/root/aps1 -s core-aps1-root
+      - command: terraform deploy security-hub/root/apne3 -s core-apne3-root
+      - command: terraform deploy security-hub/root/apne2 -s core-apne2-root
+      - command: terraform deploy security-hub/root/apne1 -s core-apne1-root
+      - command: terraform deploy security-hub/root/apse1 -s core-apse1-root
+      - command: terraform deploy security-hub/root/apse2 -s core-apse2-root
+      - command: terraform deploy security-hub/root/cac1 -s core-cac1-root
+      - command: terraform deploy security-hub/root/euc1 -s core-euc1-root
+      - command: terraform deploy security-hub/root/euw1 -s core-euw1-root
+      - command: terraform deploy security-hub/root/euw2 -s core-euw2-root
+      - command: terraform deploy security-hub/root/euw3 -s core-euw3-root
+      - command: terraform deploy security-hub/root/eun1 -s core-eun1-root
+      - command: terraform deploy security-hub/root/sae1 -s core-sae1-root
+
+  deploy/security-hub/step3:
+    description: Deploy Security Hub Organization Settings to Delegated Administrator account (core-security)
+    steps:
+      - command: terraform deploy security-hub/org-settings/use1 -s core-use1-security
+      - command: terraform deploy security-hub/org-settings/use2 -s core-use2-security
+      - command: terraform deploy security-hub/org-settings/usw1 -s core-usw1-security
+      - command: terraform deploy security-hub/org-settings/usw2 -s core-usw2-security
+      - command: terraform deploy security-hub/org-settings/aps1 -s core-aps1-security
+      - command: terraform deploy security-hub/org-settings/apne3 -s core-apne3-security
+      - command: terraform deploy security-hub/org-settings/apne2 -s core-apne2-security
+      - command: terraform deploy security-hub/org-settings/apne1 -s core-apne1-security
+      - command: terraform deploy security-hub/org-settings/apse1 -s core-apse1-security
+      - command: terraform deploy security-hub/org-settings/apse2 -s core-apse2-security
+      - command: terraform deploy security-hub/org-settings/cac1 -s core-cac1-security
+      - command: terraform deploy security-hub/org-settings/euc1 -s core-euc1-security
+      - command: terraform deploy security-hub/org-settings/euw1 -s core-euw1-security
+      - command: terraform deploy security-hub/org-settings/euw2 -s core-euw2-security
+      - command: terraform deploy security-hub/org-settings/euw3 -s core-euw3-security
+      - command: terraform deploy security-hub/org-settings/eun1 -s core-eun1-security
+      - command: terraform deploy security-hub/org-settings/sae1 -s core-sae1-security
+
+  deploy/guardduty/step1:
+    description: Deploy GuardDuty to Delegated Administrator account (core-security)
+    steps:
+      - command: terraform deploy guardduty/delegated-administrator/use1 -s core-use1-security
+      - command: terraform deploy guardduty/delegated-administrator/use2 -s core-use2-security
+      - command: terraform deploy guardduty/delegated-administrator/usw1 -s core-usw1-security
+      - command: terraform deploy guardduty/delegated-administrator/usw2 -s core-usw2-security
+      - command: terraform deploy guardduty/delegated-administrator/aps1 -s core-aps1-security
+      - command: terraform deploy guardduty/delegated-administrator/apne3 -s core-apne3-security
+      - command: terraform deploy guardduty/delegated-administrator/apne2 -s core-apne2-security
+      - command: terraform deploy guardduty/delegated-administrator/apne1 -s core-apne1-security
+      - command: terraform deploy guardduty/delegated-administrator/apse1 -s core-apse1-security
+      - command: terraform deploy guardduty/delegated-administrator/apse2 -s core-apse2-security
+      - command: terraform deploy guardduty/delegated-administrator/cac1 -s core-cac1-security
+      - command: terraform deploy guardduty/delegated-administrator/euc1 -s core-euc1-security
+      - command: terraform deploy guardduty/delegated-administrator/euw1 -s core-euw1-security
+      - command: terraform deploy guardduty/delegated-administrator/euw2 -s core-euw2-security
+      - command: terraform deploy guardduty/delegated-administrator/euw3 -s core-euw3-security
+      - command: terraform deploy guardduty/delegated-administrator/eun1 -s core-eun1-security
+      - command: terraform deploy guardduty/delegated-administrator/sae1 -s core-sae1-security
+
+  deploy/guardduty/step2:
+    description: Deploy GuardDuty to AWS Organizations Management Account (core-root). You must be SuperAdmin to run this workflow.
+    steps:
+      - command: terraform deploy guardduty/root/use1 -s core-use1-root
+      - command: terraform deploy guardduty/root/use2 -s core-use2-root
+      - command: terraform deploy guardduty/root/usw1 -s core-usw1-root
+      - command: terraform deploy guardduty/root/usw2 -s core-usw2-root
+      - command: terraform deploy guardduty/root/aps1 -s core-aps1-root
+      - command: terraform deploy guardduty/root/apne3 -s core-apne3-root
+      - command: terraform deploy guardduty/root/apne2 -s core-apne2-root
+      - command: terraform deploy guardduty/root/apne1 -s core-apne1-root
+      - command: terraform deploy guardduty/root/apse1 -s core-apse1-root
+      - command: terraform deploy guardduty/root/apse2 -s core-apse2-root
+      - command: terraform deploy guardduty/root/cac1 -s core-cac1-root
+      - command: terraform deploy guardduty/root/euc1 -s core-euc1-root
+      - command: terraform deploy guardduty/root/euw1 -s core-euw1-root
+      - command: terraform deploy guardduty/root/euw2 -s core-euw2-root
+      - command: terraform deploy guardduty/root/euw3 -s core-euw3-root
+      - command: terraform deploy guardduty/root/eun1 -s core-eun1-root
+      - command: terraform deploy guardduty/root/sae1 -s core-sae1-root
+
+  deploy/guardduty/step3:
+    description: Deploy GuardDuty Organization Settings to Delegated Administrator account (core-security)
+    steps:
+      - command: terraform deploy guardduty/org-settings/use1 -s core-use1-security
+      - command: terraform deploy guardduty/org-settings/use2 -s core-use2-security
+      - command: terraform deploy guardduty/org-settings/usw1 -s core-usw1-security
+      - command: terraform deploy guardduty/org-settings/usw2 -s core-usw2-security
+      - command: terraform deploy guardduty/org-settings/aps1 -s core-aps1-security
+      - command: terraform deploy guardduty/org-settings/apne3 -s core-apne3-security
+      - command: terraform deploy guardduty/org-settings/apne2 -s core-apne2-security
+      - command: terraform deploy guardduty/org-settings/apne1 -s core-apne1-security
+      - command: terraform deploy guardduty/org-settings/apse1 -s core-apse1-security
+      - command: terraform deploy guardduty/org-settings/apse2 -s core-apse2-security
+      - command: terraform deploy guardduty/org-settings/cac1 -s core-cac1-security
+      - command: terraform deploy guardduty/org-settings/euc1 -s core-euc1-security
+      - command: terraform deploy guardduty/org-settings/euw1 -s core-euw1-security
+      - command: terraform deploy guardduty/org-settings/euw2 -s core-euw2-security
+      - command: terraform deploy guardduty/org-settings/euw3 -s core-euw3-security
+      - command: terraform deploy guardduty/org-settings/eun1 -s core-eun1-security
+      - command: terraform deploy guardduty/org-settings/sae1 -s core-sae1-security
+
+  destroy/aws-config/global-collector:
+    description: Destroy AWS Config from accounts that require superadmin to apply
+    steps:
+      # Note that central region 'use1' and central account 'security' should be the last one destroyed
+      - command: terraform destroy aws-config-use2 -s core-use2-security -auto-approve
+      - command: terraform destroy aws-config-usw1 -s core-usw1-security -auto-approve
+      - command: terraform destroy aws-config-usw2 -s core-usw2-security -auto-approve
+      - command: terraform destroy aws-config-aps1 -s core-aps1-security -auto-approve
+      - command: terraform destroy aws-config-apne3 -s core-apne3-security -auto-approve
+      - command: terraform destroy aws-config-apne2 -s core-apne2-security -auto-approve
+      - command: terraform destroy aws-config-apne1 -s core-apne1-security -auto-approve
+      - command: terraform destroy aws-config-apse1 -s core-apse1-security -auto-approve
+      - command: terraform destroy aws-config-apse2 -s core-apse2-security -auto-approve
+      - command: terraform destroy aws-config-cac1 -s core-cac1-security -auto-approve
+      - command: terraform destroy aws-config-euc1 -s core-euc1-security -auto-approve
+      - command: terraform destroy aws-config-euw1 -s core-euw1-security -auto-approve
+      - command: terraform destroy aws-config-euw2 -s core-euw2-security -auto-approve
+      - command: terraform destroy aws-config-euw3 -s core-euw3-security -auto-approve
+      - command: terraform destroy aws-config-eun1 -s core-eun1-security -auto-approve
+      - command: terraform destroy aws-config-sae1 -s core-sae1-security -auto-approve
+      - command: terraform destroy aws-config-use1 -s core-use1-security -auto-approve
+
+  deploy/audit-manager-bucket:
+    description: Deploy bucket to hold Audit Manager finders
+    steps:
+      - command: terraform deploy s3-bucket/audit-manager -s core-use1-security
+
+  deploy/route53-resolver-dns-firewall-buckets:
+    description: Deploy Route53 Firewall S3 Buckets
+    steps:
+      - command: terraform deploy route53-resolver-dns-firewall-logs -s plat-use1-dev
+      - command: terraform deploy route53-resolver-dns-firewall-logs -s plat-use1-prod
+      - command: terraform deploy route53-resolver-dns-firewall-logs -s plat-use1-sandbox
+      - command: terraform deploy route53-resolver-dns-firewall-logs -s plat-use1-staging
+
+  deploy/route53-resolver-dns-firewall:
+    description: Deploy Route53 Firewall
+    steps:
+      - command: terraform deploy route53-resolver-dns-firewall/dev -s plat-use1-dev
+      - command: terraform deploy route53-resolver-dns-firewall/prod -s plat-use1-prod
+      - command: terraform deploy route53-resolver-dns-firewall/sandbox -s plat-use1-sandbox
+      - command: terraform deploy route53-resolver-dns-firewall/staging -s plat-use1-staging
+
+  deploy/aws-shield:
+    description: Deploys AWS Shield
+    steps:
+      - command: terraform deploy aws-shield -s plat-use1-dev
+      - command: terraform deploy aws-shield -s plat-use1-prod
+      - command: terraform deploy aws-shield -s plat-use1-sandbox
+      - command: terraform deploy aws-shield -s plat-use1-staging
+
+  deploy/aws-inspector2/step1:
+    description: Configure AWS Delegated Administrator account across all regions for AWS Inspector
+    steps:
+      - command: terraform deploy aws-inspector2/delegate-orgadmin/use1 -s core-use1-root
+      - command: terraform deploy aws-inspector2/delegate-orgadmin/use2 -s core-use2-root
+      - command: terraform deploy aws-inspector2/delegate-orgadmin/usw1 -s core-usw1-root
+      - command: terraform deploy aws-inspector2/delegate-orgadmin/usw2 -s core-usw2-root
+      - command: terraform deploy aws-inspector2/delegate-orgadmin/aps1 -s core-aps1-root
+      - command: terraform deploy aws-inspector2/delegate-orgadmin/apne3 -s core-apne3-root
+      - command: terraform deploy aws-inspector2/delegate-orgadmin/apne2 -s core-apne2-root
+      - command: terraform deploy aws-inspector2/delegate-orgadmin/apne1 -s core-apne1-root
+      - command: terraform deploy aws-inspector2/delegate-orgadmin/apse1 -s core-apse1-root
+      - command: terraform deploy aws-inspector2/delegate-orgadmin/apse2 -s core-apse2-root
+      - command: terraform deploy aws-inspector2/delegate-orgadmin/cac1 -s core-cac1-root
+      - command: terraform deploy aws-inspector2/delegate-orgadmin/euc1 -s core-euc1-root
+      - command: terraform deploy aws-inspector2/delegate-orgadmin/euw1 -s core-euw1-root
+      - command: terraform deploy aws-inspector2/delegate-orgadmin/euw2 -s core-euw2-root
+      - command: terraform deploy aws-inspector2/delegate-orgadmin/euw3 -s core-euw3-root
+      - command: terraform deploy aws-inspector2/delegate-orgadmin/eun1 -s core-eun1-root
+      - command: terraform deploy aws-inspector2/delegate-orgadmin/sae1 -s core-sae1-root
+
+  deploy/aws-inspector2/step2:
+    description: Deploy to the Delegated Administrator account to establish organization wide configuration
+    steps:
+      # There is a bug that tries to deploy Lambda Code scanning even though it's not enabled
+      # https://github.com/hashicorp/terraform-provider-aws/issues/34039
+      # For now, we'll enable Inspector only in regions that support Lambda Code scanning
+      - command: terraform deploy aws-inspector2/org-settings/use1 -s core-use1-security
+      - command: terraform deploy aws-inspector2/org-settings/use2 -s core-use2-security
+      - command: terraform deploy aws-inspector2/org-settings/usw2 -s core-usw2-security
+      - command: terraform deploy aws-inspector2/org-settings/apne1 -s core-apne1-security
+      - command: terraform deploy aws-inspector2/org-settings/apse1 -s core-apse1-security
+      - command: terraform deploy aws-inspector2/org-settings/apse2 -s core-apse2-security
+      - command: terraform deploy aws-inspector2/org-settings/euc1 -s core-euc1-security
+      - command: terraform deploy aws-inspector2/org-settings/euw1 -s core-euw1-security
+      - command: terraform deploy aws-inspector2/org-settings/euw2 -s core-euw2-security
+      - command: terraform deploy aws-inspector2/org-settings/eun1 -s core-eun1-security

--- a/examples/legacy/snippets/stacks/workflows/data.yaml
+++ b/examples/legacy/snippets/stacks/workflows/data.yaml
@@ -1,0 +1,124 @@
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: workflow vendor -f data
+      - command: workflow deploy/all -f data
+
+  vendor:
+    description: Vendor addon components.
+    steps:
+    - command: vendor pull --component aurora-postgres
+    - command: vendor pull --component aurora-postgres-resources
+    - command: vendor pull --component aurora-mysql
+    - command: vendor pull --component aurora-mysql-resources
+    - command: vendor pull --component aws-backup
+    - command: vendor pull --component documentdb
+    - command: vendor pull --component dynamodb
+    - command: vendor pull --component elasticsearch
+    - command: vendor pull --component rds
+    - command: vendor pull --component redshift
+    - command: vendor pull --component elasticache-redis
+
+  deploy/all:
+    description: run all deploy workflows
+    steps:
+      - command: workflow deploy/aurora-postgres -f data
+      - command: workflow deploy/aurora-postgres-resources -f data
+      - command: workflow deploy/aurora-mysql -f data
+      - command: workflow deploy/aurora-mysql-resources -f data
+      - command: workflow deploy/aws-backup -f data
+      - command: workflow deploy/documentdb -f data
+      - command: workflow deploy/dynamodb -f data
+      - command: workflow deploy/elasticsearch -f data
+      - command: workflow deploy/rds -f data
+      - command: workflow deploy/redshift -f data
+      - command: workflow deploy/elasticache-redis -f data
+
+  deploy/aws-backup:
+    description: >-
+      Deploy Aws Backup Component.
+    steps:
+      - command: terraform deploy aws-backup/common -s plat-use1-dev
+      - command: terraform deploy aws-backup/daily-plan -s plat-use1-dev
+      - command: terraform deploy aws-backup/weekly-plan -s plat-use1-dev
+      - command: terraform deploy aws-backup/monthly-plan -s plat-use1-dev
+      - command: terraform deploy aws-backup/common -s plat-use1-staging
+      - command: terraform deploy aws-backup/daily-plan -s plat-use1-staging
+      - command: terraform deploy aws-backup/weekly-plan -s plat-use1-staging
+      - command: terraform deploy aws-backup/monthly-plan -s plat-use1-staging
+      - command: terraform deploy aws-backup/common -s plat-use1-prod
+      - command: terraform deploy aws-backup/daily-plan -s plat-use1-prod
+      - command: terraform deploy aws-backup/weekly-plan -s plat-use1-prod
+      - command: terraform deploy aws-backup/monthly-plan -s plat-use1-prod
+  
+
+  deploy/aurora-postgres:
+    description: >-
+      Deploy Aurora-Postgres Component.
+    steps:
+      - command: terraform deploy aurora-postgres -s plat-use1-dev
+      - command: terraform deploy aurora-postgres -s plat-use1-staging
+      - command: terraform deploy aurora-postgres -s plat-use1-prod
+
+  deploy/aurora-postgres-resources:
+    description: >-
+      Deploy Aurora-Postgres-Resources Component.
+    steps:
+      - command: terraform deploy aurora-postgres-resources -s plat-use1-dev
+      - command: terraform deploy aurora-postgres-resources -s plat-use1-staging
+      - command: terraform deploy aurora-postgres-resources -s plat-use1-prod
+
+  deploy/aurora-mysql:
+    description: >-
+      Deploy Aurora-Mysql Component.
+    steps:
+      - command: terraform deploy aurora-mysql -s plat-use1-dev
+      - command: terraform deploy aurora-mysql -s plat-use1-staging
+      - command: terraform deploy aurora-mysql -s plat-use1-prod
+
+  deploy/aurora-mysql-resources:
+    description: >-
+      Deploy Aurora-Mysql-Resources Component.
+    steps:
+      - command: terraform deploy aurora-mysql-resources -s plat-use1-dev
+      - command: terraform deploy aurora-mysql-resources -s plat-use1-staging
+      - command: terraform deploy aurora-mysql-resources -s plat-use1-prod
+
+  deploy/documentdb:
+    description: >-
+      Deploy Documentdb Component.
+    steps:
+      - command: terraform deploy documentdb -s plat-use1-sandbox
+
+  deploy/dynamodb:
+    description: >-
+      Deploy Dynamodb Component.
+    steps:
+      - command: terraform deploy dynamodb -s plat-use1-sandbox
+
+  deploy/elasticsearch:
+    description: >-
+      Deploy Elasticsearch Component.
+    steps:
+      - command: terraform deploy elasticsearch -s plat-use1-sandbox
+
+  deploy/rds:
+    description: >-
+      Deploy Rds Component.
+    steps:
+      - command: terraform deploy rds/example -s plat-use1-dev
+      - command: terraform deploy rds/example -s plat-use1-staging
+      - command: terraform deploy rds/example -s plat-use1-prod
+
+  deploy/redshift:
+    description: >-
+      Deploy Redshift Component.
+    steps:
+      - command: terraform deploy redshift -s plat-use1-sandbox
+
+  deploy/elasticache-redis:
+    description: >-
+      Deploy Elasticache-Redis Component.
+    steps:
+      - command: terraform deploy elasticache-redis/sample -s plat-use1-sandbox

--- a/examples/legacy/snippets/stacks/workflows/ecs.yaml
+++ b/examples/legacy/snippets/stacks/workflows/ecs.yaml
@@ -1,0 +1,70 @@
+
+workflows:
+
+  all:
+    description: run all workflows
+    steps:
+      - command: workflow vendor -f ecs
+      - command: workflow deploy/ecs-acm -f ecs
+      - command: workflow deploy/clusters -f ecs
+      - command: workflow deploy/echo-server -f ecs
+
+  vendor:
+    description: |
+      This workflow vendors all EKS related components to the latest provided version
+    steps:
+      - command: vendor pull --component ecs
+      - command: vendor pull --component ecs-service
+
+  deploy/ecs-acm:
+    description: |
+      This workflow deploys ACM for platform ECS Cluster ALBs
+    steps:
+      - command: terraform deploy ecs/platform/acm -s plat-use1-sandbox
+      - command: terraform deploy ecs/platform/acm -s plat-use1-dev
+      - command: terraform deploy ecs/platform/acm -s plat-use1-staging
+      - command: terraform deploy ecs/platform/acm -s plat-use1-prod
+
+  deploy/clusters:
+    description: |
+      This workflow deploys ECS Clusters
+    steps:
+      - command: terraform deploy ecs/cluster -s plat-use1-sandbox
+      - command: terraform deploy ecs/cluster -s plat-use1-dev
+      - command: terraform deploy ecs/cluster -s plat-use1-staging
+      - command: terraform deploy ecs/cluster -s plat-use1-prod
+
+  deploy/echo-server:
+    description: |
+      This workflow Deploys the echo server to the clusters
+    steps:
+      - command: terraform deploy ecs/platform/service/echo-server -s plat-use1-sandbox
+      - command: terraform deploy ecs/platform/service/echo-server -s plat-use1-dev
+      - command: terraform deploy ecs/platform/service/echo-server -s plat-use1-staging
+      - command: terraform deploy ecs/platform/service/echo-server -s plat-use1-prod
+      - command: terraform deploy ecs/platform/service/echo-server-private -s plat-use1-sandbox
+      - command: terraform deploy ecs/platform/service/echo-server-private -s plat-use1-dev
+      - command: terraform deploy ecs/platform/service/echo-server-private -s plat-use1-staging
+      - command: terraform deploy ecs/platform/service/echo-server-private -s plat-use1-prod
+
+  destroy/echo-server:
+    description: |
+      This workflow Deploys the echo server to the clusters
+    steps:
+      - command: terraform destroy ecs/platform/service/echo-server -s plat-use1-sandbox -auto-approve
+      - command: terraform destroy ecs/platform/service/echo-server -s plat-use1-dev -auto-approve
+      - command: terraform destroy ecs/platform/service/echo-server -s plat-use1-staging -auto-approve
+      - command: terraform destroy ecs/platform/service/echo-server -s plat-use1-prod -auto-approve
+      - command: terraform destroy ecs/platform/service/echo-server-private -s plat-use1-sandbox -auto-approve
+      - command: terraform destroy ecs/platform/service/echo-server-private -s plat-use1-dev -auto-approve
+      - command: terraform destroy ecs/platform/service/echo-server-private -s plat-use1-staging -auto-approve
+      - command: terraform destroy ecs/platform/service/echo-server-private -s plat-use1-prod -auto-approve
+
+  destroy/clusters:
+    description: |
+      This workflow deploys ECS Clusters
+    steps:
+      - command: terraform destroy ecs/cluster -s plat-use1-sandbox -auto-approve
+      - command: terraform destroy ecs/cluster -s plat-use1-dev -auto-approve
+      - command: terraform destroy ecs/cluster -s plat-use1-staging -auto-approve
+      - command: terraform destroy ecs/cluster -s plat-use1-prod -auto-approve

--- a/examples/legacy/snippets/stacks/workflows/eks.yaml
+++ b/examples/legacy/snippets/stacks/workflows/eks.yaml
@@ -1,0 +1,99 @@
+
+workflows:
+  vendor:
+    description: |
+      This workflow vendors all EKS related components to the latest provided version
+    steps:
+      - command: vendor pull --component iam-service-linked-roles
+      - command: vendor pull --component eks/cluster
+      - command: vendor pull --component efs
+      - command: vendor pull --component eks/storage-class
+      - command: vendor pull --component eks/karpenter
+      - command: vendor pull --component eks/karpenter-node-pool
+      - command: vendor pull --component eks/external-secrets-operator
+      - command: vendor pull --component eks/external-dns
+      - command: vendor pull --component eks/reloader
+      - command: vendor pull --component eks/metrics-server
+      - command: vendor pull --component eks/cert-manager
+      - command: vendor pull --component eks/alb-controller
+      - command: vendor pull --component eks/alb-controller-ingress-group
+      - command: vendor pull --component eks/echo-server
+      - command: vendor pull --component eks/idp-roles
+
+  deploy/iam-service-linked-roles:
+    description: |
+      This workflow deploys IAM Service Linked Roles required for EKS and Karpenter
+    steps:
+      - command: terraform deploy iam-service-linked-roles -s plat-gbl-dev
+      - command: terraform deploy iam-service-linked-roles -s plat-gbl-staging
+      - command: terraform deploy iam-service-linked-roles -s plat-gbl-prod
+
+  deploy/cluster:
+    description: |
+      This workflow creates (or updates) an empty EKS cluster with eks and efs
+      ready to go.
+
+      This is stack agnostic, ensure you pass in the `-s plat-${region}-${stage}`
+      argument.
+    steps:
+      - command: terraform deploy eks/cluster
+      - command: terraform deploy efs
+      - command: terraform deploy eks/storage-class
+
+  destroy/cluster:
+    description: |
+      *CAUTION* This workflow destroys an EKS cluster
+
+      This is stack agnostic, ensure you pass in the `-s plat-${region}-${stage}`
+      argument.
+    steps:
+      - type: shell
+        command: |-
+          echo "Destroying Targeted EKS Cluster"
+          echo "Proceed with caution!\n\n"
+
+          read -p "Continue? (yes/no) " -r CONTINUE
+          if [[ "$CONTINUE" != "yes" ]]
+          then
+            echo "Exiting."
+            exit 0
+          fi
+
+          echo "Continuing with EKS destruction..."
+
+      - command: terraform destroy eks/echo-server -auto-approve
+      - command: terraform destroy eks/alb-controller-ingress-group -auto-approve
+      - command: terraform destroy eks/alb-controller-ingress-group/internal -auto-approve
+      - command: terraform destroy eks/alb-controller -auto-approve
+      - command: terraform destroy eks/cert-manager -auto-approve
+      - command: terraform destroy eks/metrics-server -auto-approve
+      - command: terraform destroy eks/reloader -auto-approve
+      - command: terraform destroy eks/external-dns -auto-approve
+      - command: terraform destroy eks/idp-roles -auto-approve
+      - command: terraform destroy eks/external-secrets-operator -auto-approve
+      - command: terraform destroy eks/karpenter-node-pool -auto-approve
+      - command: terraform destroy eks/karpenter -auto-approve
+      - command: terraform destroy eks/storage-class
+      - command: terraform destroy eks/cluster -auto-approve
+
+  deploy/resources:
+    description: |
+      This workflow creates or updates all shared components in an
+      EKS cluster. It is especially useful for (re)creating a cluster
+      in a given stack (e.g. bringing up a cluster in a new region).
+
+      This is stack agnostic, ensure you pass in the `-s ${tenant}-${region}-${stage}`
+      argument.
+    steps:
+      - command: terraform deploy eks/karpenter
+      - command: terraform deploy eks/karpenter-node-pool
+      - command: terraform deploy eks/external-secrets-operator
+      - command: terraform deploy eks/idp-roles
+      - command: terraform deploy eks/external-dns
+      - command: terraform deploy eks/reloader
+      - command: terraform deploy eks/metrics-server
+      - command: terraform deploy eks/cert-manager
+      - command: terraform deploy eks/alb-controller
+      - command: terraform deploy eks/alb-controller-ingress-group
+      - command: terraform deploy eks/alb-controller-ingress-group/internal
+      - command: terraform deploy eks/echo-server

--- a/examples/legacy/snippets/stacks/workflows/github.yaml
+++ b/examples/legacy/snippets/stacks/workflows/github.yaml
@@ -1,0 +1,26 @@
+
+workflows:
+  vendor:
+    description: |
+      This workflow vendors all RunsOn self-hosted runner related components to the latest provided version
+    steps:
+      - command: vendor pull --component github-oidc-provider
+      - command: vendor pull --component runs-on
+
+  deploy/github-oidc-provider:
+    description: |
+      This workflow deploys Github OIDC Provider Configuration for Github Runners
+    steps:
+      - command: terraform deploy github-oidc-provider -s core-gbl-identity
+      - command: terraform deploy github-oidc-provider -s core-gbl-artifacts
+      - command: terraform deploy github-oidc-provider -s core-gbl-auto
+      - command: terraform deploy github-oidc-provider -s plat-gbl-dev
+      - command: terraform deploy github-oidc-provider -s plat-gbl-sandbox
+      - command: terraform deploy github-oidc-provider -s plat-gbl-staging
+      - command: terraform deploy github-oidc-provider -s plat-gbl-prod
+
+  deploy/runs-on:
+    description: |
+      This workflow deploys Runs-On Github Runners
+    steps:
+      - command: terraform deploy runs-on -s core-use1-auto

--- a/examples/legacy/snippets/stacks/workflows/gitops.yaml
+++ b/examples/legacy/snippets/stacks/workflows/gitops.yaml
@@ -1,0 +1,36 @@
+
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: workflow vendor -f gitops
+      - command: workflow deploy/all -f gitops
+
+  vendor:
+    description: Vendor gitops required components.
+    steps:
+    - command: vendor pull --component github-oidc-role
+    - command: vendor pull --component dynamodb
+    - command: vendor pull --component s3-bucket
+
+  deploy/all:
+    description: Run all deploy workflows
+    steps:
+      - command: workflow deploy/github-oidc-provider -f github
+      - command: workflow deploy/gitops -f gitops
+
+  deploy/gitops:
+    description: Run deploy workflows for Gitops requirements
+    steps:
+      - command: terraform deploy gitops/s3-bucket --stack core-use1-auto
+      - command: terraform deploy gitops/dynamodb --stack core-use1-auto
+      - command: terraform deploy github-oidc-role/gitops --stack core-use1-auto
+
+  deploy/github-oidc-provider:
+    description: Deploys GitHub OIDC provider to every included account.
+    steps:
+      - command: workflow deploy/github-oidc-provider -f github
+      - command: terraform deploy github-oidc-provider -s core-gbl-audit
+      - command: terraform deploy github-oidc-provider -s core-gbl-dns
+      - command: terraform deploy github-oidc-provider -s core-gbl-network
+      - command: terraform deploy github-oidc-provider -s core-gbl-security

--- a/examples/legacy/snippets/stacks/workflows/grafana.yaml
+++ b/examples/legacy/snippets/stacks/workflows/grafana.yaml
@@ -1,0 +1,43 @@
+
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: workflow vendor -f grafana
+      - command: workflow deploy -f grafana
+
+  vendor:
+    description: vendor dependencies
+    steps:
+      - command: vendor pull --component
+
+  deploy:
+    description: deploys all Grafana data sources into plat accounts
+    steps:
+      - command: workflow deploy/data-sources -s plat-use1-dev -f grafana
+      - command: workflow deploy/data-sources -s plat-use1-staging -f grafana
+      - command: workflow deploy/data-sources -s plat-use1-prod -f grafana
+      - command: workflow deploy/grafana -s core-use1-auto -f grafana
+
+  deploy/data-sources:
+    description: deploys all Grafana data sources into a given stack
+    steps:
+      - command: terraform deploy prometheus
+      - command: terraform deploy eks/prometheus-scraper
+      - command: terraform deploy eks/loki
+      - command: terraform deploy eks/promtail
+      - type: shell
+        command: |-
+          echo "Now update the eks/cluster map_additional_iam_roles and reapply eks/cluster"
+
+  deploy/grafana:
+    description: deploys centralized Grafana and all sub components
+    steps:
+      - command: terraform deploy grafana -s core-use1-auto
+      - command: terraform deploy grafana/api-key -s core-use1-auto
+      - command: terraform deploy grafana/dashboard/plat-dev-prometheus -s core-use1-auto
+      - command: terraform deploy grafana/dashboard/plat-dev-loki -s core-use1-auto
+      - command: terraform deploy grafana/dashboard/plat-staging-prometheus -s core-use1-auto
+      - command: terraform deploy grafana/dashboard/plat-staging-loki -s core-use1-auto
+      - command: terraform deploy grafana/dashboard/plat-prod-prometheus -s core-use1-auto
+      - command: terraform deploy grafana/dashboard/plat-prod-loki -s core-use1-auto

--- a/examples/legacy/snippets/stacks/workflows/identity.yaml
+++ b/examples/legacy/snippets/stacks/workflows/identity.yaml
@@ -1,0 +1,112 @@
+
+workflows:
+  check-setup:
+    description: Verify that the environment is setup correctly to run these workflows.
+    steps:
+    - name: check-setup
+      type: shell
+      command : |-
+        if [[ "$GEODESIC_SHELL" != "true" ]]; then
+          echo "This workflow must be run from a Geodesic shell." >&2
+          exit 1
+        elif [[ -z $ATMOS_BASE_PATH ]] || [[ ! -d "$ATMOS_BASE_PATH/.git" ]]; then
+          echo "ATMOS_BASE_PATH must be set to the root of the git repository." >&2
+          echo "This is usually set automatically by Geodesic." >&2
+          echo "To fix: run the Geodesic shell from the root of the git repository." >&2
+          echo "  ATMOS_BASE_PATH: \"$ATMOS_BASE_PATH\"" >&2
+          echo "  Current directory: \"$(pwd -P)\"" >&2
+          exit 1
+        elif [[ ! -d "$ATMOS_BASE_PATH/rootfs/usr/local/bin" ]]; then
+          printf "No such directory: %s\n" "$ATMOS_BASE_PATH/rootfs/usr/local/bin" >&2
+          exit 2
+        fi
+
+  all:
+    description: Run all workflows
+    steps:
+      - command: workflow check-setup -f identity
+      - command: workflow vendor -f identity
+      - command: workflow deploy/all -f identity
+
+  vendor:
+    description: Vendor identity layer components and scripts.
+    steps:
+      - command: workflow vendor/components -f identity
+      - command: workflow vendor/aws-config -f identity
+
+  vendor/components:
+    description: Vendor identity layer components.
+    steps:
+      - command: vendor pull --component aws-saml
+      - command: vendor pull --component aws-sso
+      - command: vendor pull --component aws-team-roles
+      - command: vendor pull --component aws-teams
+
+  vendor/aws-config:
+    description: Vendor aws-config script.
+    steps:
+      - name: vendor-aws-config
+        type: shell
+        command: |-
+          set -e
+          : "${ATMOS_BASE_PATH:=.}"
+          AWS_CONFIG_VERSION="1.227.0"
+          printf "Updating AWS Config in $ATMOS_BASE_PATH/rootfs/usr/local/bin/aws-config\n"
+          printf "Note: Rebuild Geodesic to apply script updates\n"
+          curl -fsSL https://raw.githubusercontent.com/cloudposse/terraform-aws-components/$AWS_CONFIG_VERSION/rootfs/usr/local/bin/aws-config -o "$ATMOS_BASE_PATH/rootfs/usr/local/bin/aws-config"
+          chmod +x "$ATMOS_BASE_PATH/rootfs/usr/local/bin/aws-config"
+
+  deploy/all:
+    description: Deploy all identity components.
+    steps:
+      - command: workflow deploy/saml -f identity
+      - command: workflow deploy/sso -f identity
+      - command: workflow deploy/teams -f identity
+      - command: workflow update-aws-config -f identity
+
+  deploy/saml:
+    description: Update aws-saml configuration (when adding a new Identity Provider).
+    steps:
+      - command: terraform deploy aws-saml -s core-gbl-identity
+
+  deploy/sso:
+    description: Update aws-sso configuration.
+    steps:
+      - command: terraform deploy aws-sso -s core-gbl-root
+
+  deploy/teams:
+    description: Establish cross account AWS Teams roles for access.
+    steps:
+      - command: terraform deploy aws-teams -s core-gbl-identity
+      - command: terraform deploy aws-team-roles -s core-gbl-artifacts
+      - command: terraform deploy aws-team-roles -s core-gbl-audit
+      - command: terraform deploy aws-team-roles -s core-gbl-auto
+      - command: terraform deploy aws-team-roles -s core-gbl-dns
+      - command: terraform deploy aws-team-roles -s core-gbl-identity
+      - command: terraform deploy aws-team-roles -s core-gbl-network
+      - command: terraform deploy aws-team-roles -s core-gbl-root
+      - command: terraform deploy aws-team-roles -s core-gbl-security
+      - command: terraform deploy aws-team-roles -s plat-gbl-dev
+      - command: terraform deploy aws-team-roles -s plat-gbl-prod
+      - command: terraform deploy aws-team-roles -s plat-gbl-sandbox
+      - command: terraform deploy aws-team-roles -s plat-gbl-staging
+
+  update-aws-config:
+    description: Update AWS Config files.
+    steps:
+      - name: update-aws-config
+        type: shell
+        command: |-
+          set -e
+          printf "Updating AWS Config files in $ATMOS_BASE_PATH/rootfs/etc/aws-config\n"
+          aws-config teams > "$ATMOS_BASE_PATH/rootfs/etc/aws-config/aws-config-teams"
+          aws-config switch-roles > "$ATMOS_BASE_PATH/rootfs/etc/aws-config/aws-extend-switch-roles"
+          aws-config switch-roles planner > "$ATMOS_BASE_PATH/rootfs/etc/aws-config/aws-extend-switch-roles-planner"
+
+          diffs=$(git diff --name-only "$ATMOS_BASE_PATH/rootfs/etc/aws-config")
+          if [[ -n $diffs ]] then
+            printf "Updated: %s\n" "${diffs[@]}"
+            printf "Note: Rebuild Geodesic to apply script updates\n"
+          else
+            printf "No changes\n"
+          fi

--- a/examples/legacy/snippets/stacks/workflows/monitoring.yaml
+++ b/examples/legacy/snippets/stacks/workflows/monitoring.yaml
@@ -1,0 +1,159 @@
+
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: workflow init -f monitoring
+      - command: workflow vendor -f monitoring
+      - command: workflow deploy/datadog-configuration -f monitoring
+      - command: workflow deploy/datadog-integration -f monitoring
+#      - command: workflow deploy/datadog-logs-archive -f monitoring
+      - command: workflow deploy/datadog-monitor -f monitoring
+      - command: workflow deploy/datadog-lambda-forwarder -f monitoring
+      - command: workflow deploy/datadog-agent -f monitoring
+      - command: workflow deploy/datadog-synthetics-private-location -f monitoring
+      - command: workflow deploy/datadog-private-location-ecs -f monitoring
+
+  init:
+    description: Prompt for uploading Datadog API Key to AWS SSM
+    steps:
+      - type: shell
+        command: |-
+          echo "Please enter a Datadog API Key"
+
+          stty -echo
+          read -p "API Key: " -r API_KEY
+          stty echo
+          if [ -z "$API_KEY" ]
+          then
+              echo 'Inputs cannot be blank please try again!'
+              exit 0
+          fi
+          if ! [[ "$API_KEY" =~ "^[a-zA-Z0-9-]{32}$" ]]
+          then
+              echo "Invalid API Key"
+              echo "HINT: The API key ID is displayed as an upper-case, 32-character alphanumeric value."
+              exit 0
+          fi
+
+          stty -echo
+          read -p "APP Key: " -r APP_KEY
+          stty echo
+          if [ -z "$APP_KEY" ]
+          then
+             echo 'Inputs cannot be blank please try again!'
+             exit 0
+          fi
+          if ! [[ "$APP_KEY" =~ "^[a-zA-Z0-9]{40}$" ]]
+          then
+             echo "Invalid APP Key"
+             exit 0
+          fi
+
+          AWS_PROFILE=acme-core-gbl-auto-admin aws ssm put-parameter --name /datadog/default/datadog_api_key --value $API_KEY --type SecureString
+          AWS_PROFILE=acme-core-gbl-auto-admin aws ssm put-parameter --name /datadog/default/datadog_app_key --value $APP_KEY --type SecureString
+
+  vendor:
+    description: vendor dependencies
+    steps:
+      - command: vendor pull --component datadog-configuration
+      - command: vendor pull --component datadog-integration
+      - command: vendor pull --component datadog-lambda-forwarder
+      - command: vendor pull --component datadog-monitor
+      #- command: vendor pull --component datadog-logs-archive
+      - command: vendor pull --component eks/datadog-agent
+      - command: vendor pull --component datadog-synthetics-private-location
+      - command: vendor pull --component datadog-private-location-ecs
+
+  deploy/datadog-configuration:
+    description: deploys all datadog-configuration components
+    steps:
+      - command: terraform deploy datadog-configuration -s core-gbl-artifacts
+      - command: terraform deploy datadog-configuration -s core-gbl-audit
+      - command: terraform deploy datadog-configuration -s core-gbl-auto
+      - command: terraform deploy datadog-configuration -s core-gbl-dns
+      - command: terraform deploy datadog-configuration -s core-gbl-network
+      - command: terraform deploy datadog-configuration -s core-gbl-security
+      - command: terraform deploy datadog-configuration -s plat-gbl-sandbox
+      - command: terraform deploy datadog-configuration -s plat-gbl-dev
+      - command: terraform deploy datadog-configuration -s plat-gbl-staging
+      - command: terraform deploy datadog-configuration -s plat-gbl-prod
+
+  deploy/datadog-integration:
+    description: deploys all datadog-integration components
+    steps:
+      - command: terraform deploy datadog-integration -s core-gbl-artifacts
+      - command: terraform deploy datadog-integration -s core-gbl-audit
+      - command: terraform deploy datadog-integration -s core-gbl-auto
+      - command: terraform deploy datadog-integration -s core-gbl-dns
+      - command: terraform deploy datadog-integration -s core-gbl-network
+      - command: terraform deploy datadog-integration -s core-gbl-security
+      - command: terraform deploy datadog-integration -s plat-gbl-sandbox
+      - command: terraform deploy datadog-integration -s plat-gbl-dev
+      - command: terraform deploy datadog-integration -s plat-gbl-staging
+      - command: terraform deploy datadog-integration -s plat-gbl-prod
+
+#  deploy/datadog-logs-archive:
+#    description: deploys all datadog-logs-archive components
+#    steps:
+#      - command: terraform deploy datadog-logs-archive -s core-gbl-artifacts
+#      - command: terraform deploy datadog-logs-archive -s core-gbl-audit
+#      - command: terraform deploy datadog-logs-archive -s core-gbl-auto
+#      - command: terraform deploy datadog-logs-archive -s core-gbl-dns
+#      - command: terraform deploy datadog-logs-archive -s core-gbl-network
+#      - command: terraform deploy datadog-logs-archive -s core-gbl-security
+#      - command: terraform deploy datadog-logs-archive -s plat-gbl-sandbox
+#      - command: terraform deploy datadog-logs-archive -s plat-gbl-dev
+#      - command: terraform deploy datadog-logs-archive -s plat-gbl-staging
+#      - command: terraform deploy datadog-logs-archive -s plat-gbl-prod
+
+  deploy/datadog-monitor:
+    description: deploys all datadog-monitor components
+    steps:
+      - command: terraform deploy datadog-monitor -s core-gbl-auto
+      - command: terraform deploy datadog-monitor -s plat-gbl-sandbox
+      - command: terraform deploy datadog-monitor -s plat-gbl-dev
+      - command: terraform deploy datadog-monitor -s plat-gbl-staging
+      - command: terraform deploy datadog-monitor -s plat-gbl-prod
+
+  deploy/datadog-lambda-forwarder:
+    description: deploys all datadog-lambda-forwarder components
+    steps:
+      - command: terraform deploy datadog-lambda-forwarder -s core-use1-artifacts
+      - command: terraform deploy datadog-lambda-forwarder -s core-use1-audit
+      - command: terraform deploy datadog-lambda-forwarder -s core-use1-auto
+      - command: terraform deploy datadog-lambda-forwarder -s core-use1-dns
+      - command: terraform deploy datadog-lambda-forwarder -s core-use1-network
+      - command: terraform deploy datadog-lambda-forwarder -s core-use1-security
+      - command: terraform deploy datadog-lambda-forwarder -s plat-use1-sandbox
+      - command: terraform deploy datadog-lambda-forwarder -s plat-use1-dev
+      - command: terraform deploy datadog-lambda-forwarder -s plat-use1-staging
+      - command: terraform deploy datadog-lambda-forwarder -s plat-use1-prod
+
+
+  deploy/datadog-agent:
+    description: deploys all datadog-agent components
+    steps:
+      - command: terraform deploy eks/datadog-agent -s core-use1-auto
+      - command: terraform deploy eks/datadog-agent -s plat-use1-dev
+      - command: terraform deploy eks/datadog-agent -s plat-use1-staging
+      - command: terraform deploy eks/datadog-agent -s plat-use1-prod
+
+  deploy/datadog-synthetics-private-location:
+    description: deploys all datadog-synthetics-private-location components
+    steps:
+      - command: terraform deploy datadog-synthetics-private-location -s core-use1-auto
+      - command: terraform deploy datadog-synthetics-private-location -s plat-use1-dev
+      - command: terraform deploy datadog-synthetics-private-location -s plat-use1-staging
+      - command: terraform deploy datadog-synthetics-private-location -s plat-use1-prod
+
+
+  deploy/datadog-private-location-ecs:
+    description: deploys all datadog-private-location-ecs components
+    steps:
+      - command: terraform deploy datadog-private-location-ecs -s core-use1-auto
+      - command: terraform deploy datadog-private-location-ecs -s plat-use1-sandbox
+      - command: terraform deploy datadog-private-location-ecs -s plat-use1-dev
+      - command: terraform deploy datadog-private-location-ecs -s plat-use1-staging
+      - command: terraform deploy datadog-private-location-ecs -s plat-use1-prod
+

--- a/examples/legacy/snippets/stacks/workflows/network.yaml
+++ b/examples/legacy/snippets/stacks/workflows/network.yaml
@@ -1,0 +1,120 @@
+workflows:
+  all:
+    description: run all workflows
+    steps:
+      - command: workflow vendor -f network
+      - command: workflow deploy/vpc -f network
+      - command: workflow deploy/tgw -f network
+      - command: workflow deploy/dns -f network
+      - command: workflow output/dns-name-servers -f network
+      - command: workflow deploy/acm -f network
+      - command: workflow deploy/vpn -f network
+      - command: workflow deploy/bastion -f network
+
+  vendor:
+    description: Vendor component dependencies for the network layer.
+    steps:
+      - command: vendor pull --component tgw/hub
+      - command: vendor pull --component tgw/spoke
+      - command: vendor pull --component acm
+      - command: vendor pull --component bastion
+      - command: vendor pull --component dns-delegated
+      - command: vendor pull --component dns-primary
+      - command: vendor pull --component ec2-client-vpn
+      - command: vendor pull --component vpc
+
+  deploy/vpc:
+    description: Provision VPCs for the network layer.
+    steps:
+      - command: terraform deploy vpc -s core-use1-auto
+      - command: terraform deploy vpc -s core-use1-network
+      - command: terraform deploy vpc -s plat-use1-sandbox
+      - command: terraform deploy vpc -s plat-use1-dev
+      - command: terraform deploy vpc -s plat-use1-staging
+      - command: terraform deploy vpc -s plat-use1-prod
+
+  # NOTE: cloud-nuke actually has a command for this. Have not tested it, but might be easier:
+  #    https://github.com/gruntwork-io/cloud-nuke#usage
+  destroy/vpc/default:
+    description: Deprovision all the AWS default VPCs.
+    steps:
+      - type: shell
+        command: wipe-default-vpcs
+
+  deploy/tgw:
+    description: Provision the Transit Gateway "hub" and "spokes" for connecting VPCs.
+    steps:
+      - command: terraform deploy tgw/hub -s core-use1-network
+        name: hub
+      - command: terraform deploy tgw/spoke -s core-use1-network
+      - command: echo 'Creating core spokes for Transit Gateway'
+        type: shell
+        name: core-spokes
+      - command: terraform deploy tgw/spoke -s core-use1-auto
+      - command: terraform deploy tgw/spoke -s plat-use1-sandbox
+      - command: echo 'Creating platform spokes for Transit Gateway'
+        type: shell
+        name: plat-spokes
+      - command: terraform deploy tgw/spoke -s plat-use1-dev
+      - command: terraform deploy tgw/spoke -s plat-use1-staging
+      - command: terraform deploy tgw/spoke -s plat-use1-prod
+
+  deploy/dns:
+    description: Configure the DNS "primary" and "delegated" stacks.
+    steps:
+      - command: echo 'Creating primary dns zones'
+        type: shell
+        name: primary
+      - command: terraform deploy dns-primary -s core-gbl-dns
+      - command: terraform deploy dns-primary -s plat-gbl-dev
+      - command: terraform deploy dns-primary -s plat-gbl-staging
+      - command: terraform deploy dns-primary -s plat-gbl-prod
+      - command: terraform deploy dns-primary -s plat-gbl-sandbox
+      - command: echo 'Creating delegated dns zones'
+        type: shell
+        name: delegated
+      - command: terraform deploy dns-delegated -s core-gbl-auto
+      - command: terraform deploy dns-delegated -s plat-gbl-sandbox
+      - command: terraform deploy dns-delegated -s plat-gbl-dev
+      - command: terraform deploy dns-delegated -s plat-gbl-staging
+      - command: terraform deploy dns-delegated -s plat-gbl-prod
+
+  output/dns-name-servers:
+    description: Output NS records for each dns-primary
+    steps:
+      - type: shell
+        command: |
+          cd components/terraform/dns-primary
+          function output-dns(){
+            terraform workspace select $1 > /dev/null
+            terraform output -json zones
+          }
+          for s in core-gbl-dns plat-gbl-{dev,staging,prod,sandbox} ; do
+            output-dns $s
+          done | jq 'to_entries[] | { (.key) : .value.name_servers }'
+
+  deploy/acm:
+    description: Provision AWS Certificate Manager for custom and ad-hoc requests.
+    steps:
+      - command: terraform deploy acm -s core-use1-auto
+      - command: terraform deploy acm -s plat-use1-sandbox
+      - command: terraform deploy acm -s plat-use1-dev
+      - command: terraform deploy acm -s plat-use1-staging
+      - command: terraform deploy acm -s plat-use1-prod
+
+  deploy/vpn:
+    description: Establish the AWS Client VPN in the core-network account.
+    steps:
+      - command: terraform deploy ec2-client-vpn -s core-use1-network
+      - type: shell
+        command: cd components/terraform/ec2-client-vpn && terraform output client_configuration | sed '1d;$d;$d' > ../../../rootfs/etc/aws-config/acme-core.ovpn
+
+  deploy/bastion:
+    description: |
+      Provision the bastion hosts, which useful for accessing resources via SSH.
+    steps:
+      - command: terraform deploy bastion -s plat-use1-sandbox
+      - command: terraform deploy bastion -s plat-use1-dev
+      - command: terraform deploy bastion -s plat-use1-staging
+      - command: terraform deploy bastion -s plat-use1-prod
+      - command: terraform deploy bastion -s core-use1-network

--- a/examples/legacy/snippets/stacks/workflows/release_engineering.yaml
+++ b/examples/legacy/snippets/stacks/workflows/release_engineering.yaml
@@ -1,0 +1,35 @@
+workflows:
+  verify/github-oidc-providers:
+    description: |
+      This workflow ensures all Github OIDC Provider Configuration deployed.
+      Please assume `acme-core-gbl-root-admin`
+    steps:
+      - command: workflow deploy/github-oidc-provider -f github
+
+  deploy/pre-requisites:
+    description: |
+      This workflow ensures all components are up to date before attempting to deploy the repos that access them.
+      Often a eks/cluster component will need to be reapplied to add OIDC access for a given repo.
+    steps:
+      - command: terraform deploy ecr -s core-use1-artifacts
+      - command: workflow deploy/acm -f network
+      - command: terraform deploy eks/cluster -s plat-use1-dev
+      - command: terraform deploy eks/cluster -s plat-use1-staging
+      - command: terraform deploy eks/cluster -s plat-use1-prod
+
+  deploy/acm:
+    description: |
+      This workflow deploys additional ACM certificates required for specific release workflow environments.
+    steps:
+      - command: terraform deploy acm/preview -s plat-use1-dev
+      - command: terraform deploy acm/hotfix -s plat-use1-dev
+      - command: terraform deploy acm/qa1 -s plat-use1-staging
+      - command: terraform deploy acm/qa2 -s plat-use1-staging
+      - command: terraform deploy acm/qa3 -s plat-use1-staging
+      - command: terraform deploy acm/qa4 -s plat-use1-staging
+
+  demo/install:
+    description: |
+      This workflow deploys GitHub repositories for release engineering demo
+    steps:
+      - command: terraform deploy release-engineering-bootstrap -s core-gbl-auto

--- a/src/components/AtmosWorkflow/constants.ts
+++ b/src/components/AtmosWorkflow/constants.ts
@@ -1,4 +1,6 @@
 // constants.ts
 
 export const CLOUDPOSSE_DOCS_URL = 'https://raw.githubusercontent.com/cloudposse/docs/master/';
-export const WORKFLOWS_DIRECTORY_PATH = 'examples/snippets/stacks/workflows/';
+// temporarily point to the legacy workflows directory until staging is complete.
+// See https://github.com/cloudposse/docs/pull/788
+export const WORKFLOWS_DIRECTORY_PATH = 'examples/legacy/snippets/stacks/workflows/';

--- a/src/components/AtmosWorkflow/index.tsx
+++ b/src/components/AtmosWorkflow/index.tsx
@@ -19,7 +19,12 @@ interface AtmosWorkflowProps {
 
 export default function AtmosWorkflow({ workflow, stack = '', fileName }: AtmosWorkflowProps) {
   const [workflowData, setWorkflowData] = useState<WorkflowData | null>(null);
-  const fullFilePath = `${WORKFLOWS_DIRECTORY_PATH}${fileName}.yaml`;
+  // Only temporarily, we're pointing all workflows to a copy of the workflow directory.
+  // However, we dont want to show the user the "legacy/" prefix in the file path, so we have a temporary trick until the staging PR is merged.
+  // Uncomment this when the staging PR is merged:
+  // const fullFilePath = `${WORKFLOWS_DIRECTORY_PATH}${fileName}.yaml`;
+  // and delete the following line:
+  const fullFilePath = `${WORKFLOWS_DIRECTORY_PATH}${fileName}.yaml`.replace('legacy/', '');
 
   useEffect(() => {
     GetAtmosTerraformCommands(workflow, fileName, stack).then((data) => {


### PR DESCRIPTION
## what
- Point all Atmos workflows to a copy of the workflow directory

## why
- When we merge the staging branch of refarch-scaffold, all workflows will be changed. That means they will break all paths on docs (here). Therefore, we can create a temporary copy of them all in this directory, point to the copy, and then update the staging branch here to point to the new path

## references
- https://github.com/cloudposse/refarch-scaffold/tree/staging