### PR TITLE
fix: Indentation for Steps

### DIFF
--- a/docs/layers/accounts/account-baseline.mdx
+++ b/docs/layers/accounts/account-baseline.mdx
@@ -50,13 +50,13 @@ Now that all the accounts have been deployed, we need to finalize the setup of t
      ```
   3. **Enable Cost Explorer** (if not already enabled). When attempting to create budgets, you may encounter the following error:
 
-  ```console
-  Error: creating Budget (xxx-core-gbl-artifacts-1000-total-monthly): operation error Budgets: CreateBudget, 
-  https response error StatusCode: 400, RequestID: xxx, 
-  AccessDeniedException: Account xxx is a linked account. To enable budgets for your account, ask the payer account to enable budgets first.
-  ```
+     ```console
+     Error: creating Budget (xxx-core-gbl-artifacts-1000-total-monthly): operation error Budgets: CreateBudget, 
+     https response error StatusCode: 400, RequestID: xxx, 
+     AccessDeniedException: Account xxx is a linked account. To enable budgets for your account, ask the payer account to enable budgets first.
+     ```
 
-  This error occurs when AWS Cost Explorer has not been activated for the organization. To resolve this, navigate to the AWS Cost Explorer console in your organization's management account and verify that Cost Explorer is enabled. Cost Explorer must be enabled at the organization level before individual member accounts can create budgets.
+     This error occurs when AWS Cost Explorer has not been activated for the organization. To resolve this, navigate to the AWS Cost Explorer console in your organization's management account and verify that Cost Explorer is enabled. Cost Explorer must be enabled at the organization level before individual member accounts can create budgets.
 
   4. **To enable budgets for the entire organization**, update `account-settings` in the same account as the Organization root account, typically `core-root`. This budget will include the total spending of all accounts in the Organization.
      ```yaml


### PR DESCRIPTION
## what
- Fix the indentation on the account deployment steps

## why
- Fix this:
<img width="1092" height="2188" alt="CleanShot 2025-09-02 at 14 22 47@2x" src="https://github.com/user-attachments/assets/e325c5df-a20a-4e64-9d3c-80caaecbb00c" />

## references
#815 
