### PR TITLE
Use atmos instead of makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,5 @@ content/reference-architecture/**
 !content/components/library/aws/_category_.json
 !content/github-actions/library/actions/_category_.json
 changelog/*
+
+.atmos

--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,9 @@ real-clean:
 
 lint:
 	npx docusaurus-mdx-checker --cwd docs
+
+readme/build:
+	@atmos docs generate readme
+
+readme:
+	@atmos docs generate readme

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 <!-- markdownlint-disable -->
 # Developer Documentation <a href="https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/docs&utm_content="><img align="right" src="https://cloudposse.com/logo-300x69.svg" width="150" /></a>
-<a href="https://github.com/cloudposse/docs/releases"><img src="https://img.shields.io/github/release/cloudposse/docs.svg?style=for-the-badge" alt="Latest Release"/></a><a href="https://slack.cloudposse.com"><img src="https://slack.cloudposse.com/for-the-badge.svg" alt="Slack Community"/></a>
+
+
+<a href="https://github.com/cloudposse/docs/releases"><img src="https://img.shields.io/github/release/cloudposse/docs.svg?style=for-the-badge" alt="Latest Release"/></a><a href="https://slack.cloudposse.com"><img src="https://slack.cloudposse.com/for-the-badge.svg" alt="Slack Community"/></a><a href="https://cloudposse.com/support/"><img src="https://img.shields.io/badge/Get_Support-success.svg?style=for-the-badge" alt="Get Support"/></a>
+
+
 <!-- markdownlint-restore -->
 
 <!--
@@ -55,17 +59,9 @@ make start
 
 
 
-<!-- markdownlint-disable -->
-## Makefile Targets
-```text
-Available targets:
 
-  help                                Help screen
-  help/all                            Display help for all targets
-  help/short                          This help short screen
 
-```
-<!-- markdownlint-restore -->
+
 
 
 ## Related Projects
@@ -99,6 +95,38 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
  6. Submit a **Pull Request** so that we can review your changes
 
 **NOTE:** Be sure to merge the latest changes from "upstream" before making a pull request!
+
+
+## Running Terraform Tests
+
+We use [Atmos](https://atmos.tools) to streamline how Terraform tests are run. It centralizes configuration and wraps common test workflows with easy-to-use commands.
+
+All tests are located in the [`test/`](test) folder.
+
+Under the hood, tests are powered by Terratest together with our internal [Test Helpers](https://github.com/cloudposse/test-helpers) library, providing robust infrastructure validation.
+
+Setup dependencies:
+- Install Atmos ([installation guide](https://atmos.tools/install/))
+- Install Go [1.24+ or newer](https://go.dev/doc/install)
+- Install Terraform or OpenTofu
+
+To run tests:
+
+- Run all tests:  
+  ```sh
+  atmos test run
+  ```
+- Clean up test artifacts:  
+  ```sh
+  atmos test clean
+  ```
+- Explore additional test options:  
+  ```sh
+  atmos test --help
+  ```
+The configuration for test commands is centrally managed. To review what's being imported, see the [`atmos.yaml`](https://raw.githubusercontent.com/cloudposse/.github/refs/heads/main/.github/atmos/terraform-module.yaml) file.
+
+Learn more about our [automated testing in our documentation](https://docs.cloudposse.com/community/contribute/automated-testing/) or implementing [custom commands](https://atmos.tools/core-concepts/custom-commands/) with atmos.
 
 ### 🌎 Slack Community
 
@@ -137,7 +165,7 @@ All other trademarks referenced herein are the property of their respective owne
 
 
 ---
-Copyright © 2017-2024 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2025 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 <a href="https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/docs&utm_content=readme_footer_link"><img alt="README footer" src="https://cloudposse.com/readme/footer/img"/></a>

--- a/README.yaml
+++ b/README.yaml
@@ -21,9 +21,6 @@ description: |-
 
   Let's jump right in! Here's how to get started with our documentation.
 
-include:
-  - "docs/targets.md"
-
 usage: |-
   1. Build dependencies
   ```

--- a/atmos.yaml
+++ b/atmos.yaml
@@ -1,0 +1,12 @@
+# Atmos Configuration — powered by https://atmos.tools
+#
+# This configuration enables centralized, DRY, and consistent project scaffolding using Atmos.
+#
+# Included features:
+# - Organizational custom commands: https://atmos.tools/core-concepts/custom-commands
+# - Automated README generation: https://atmos.tools/cli/commands/docs/generate
+#
+
+# Import shared configuration used by all modules
+import:
+  - https://raw.githubusercontent.com/cloudposse/.github/refs/heads/main/.github/atmos/default.yaml


### PR DESCRIPTION
## what
* Use atmos instead of makefile

## why
* build-harness deprecated. Use atmos instead 