### PR TITLE
Fix broken Atmos Auth links

### DIFF
--- a/blog/2026-02-25-nextgen-component-migration.mdx
+++ b/blog/2026-02-25-nextgen-component-migration.mdx
@@ -141,7 +141,7 @@ Before using Atmos Auth, ensure you have:
 1. **Atmos >= v1.155.0** — Atmos Auth requires a recent version of the Atmos CLI. Run `atmos version` to check.
 1. **AWS IAM Identity Center (SSO)** — For human users, Atmos Auth profiles authenticate via AWS SSO. You need IAM Identity Center configured in your `core-root` account with Permission Sets for Terraform access.
 1. **IAM roles for CI/CD** — For machine users, deploy the `iam-role` component with GitHub OIDC (or your CI provider's equivalent) in each target account.
-1. **Atmos Auth profiles configured** — Define profiles in your `atmos.yaml` that map to SSO Permission Sets or IAM roles. See [Atmos Auth](https://atmos.tools/cli/auth) for the configuration reference.
+1. **Atmos Auth profiles configured** — Define profiles in your `atmos.yaml` that map to SSO Permission Sets or IAM roles. See [Atmos Auth](https://atmos.tools/cli/configuration/auth) for the configuration reference.
 </Steps>
 
 ## How Provider Overrides Work
@@ -189,7 +189,7 @@ Configure Atmos Auth profiles in your `atmos.yaml`. This tells Atmos how to auth
 atmos auth login
 ```
 
-See [Atmos Auth](https://atmos.tools/cli/auth) for configuration details and the [prerequisites](#atmos-auth-prerequisites) section above.
+See [Atmos Auth](https://atmos.tools/cli/configuration/auth) for configuration details and the [prerequisites](#atmos-auth-prerequisites) section above.
 
 ### 2. Add the Static Account Map
 
@@ -503,7 +503,7 @@ The net result: fewer components to manage, simpler authentication, no deploy or
 <Steps>
 1. [Deprecating Account-Map](/blog/deprecate-account-map/) — The full deprecation announcement
 1. [Migrate from Account-Map](/layers/project/tutorials/migrate-from-account-map/) — Detailed step-by-step migration guide
-1. [Atmos Auth](https://atmos.tools/cli/auth) — Authentication configuration reference
+1. [Atmos Auth](https://atmos.tools/cli/configuration/auth) — Authentication configuration reference
 1. [How to Log into AWS](/layers/identity/how-to-log-into-aws/) — Authentication workflows for human users
 </Steps>
 

--- a/docs/layers/accounts/tutorials/legacy-account-map.mdx
+++ b/docs/layers/accounts/tutorials/legacy-account-map.mdx
@@ -8,7 +8,7 @@ import Intro from '@site/src/components/Intro';
 import Steps from '@site/src/components/Steps';
 
 <Intro>
-The `account-map` component has been deprecated. The reference architecture now uses [Atmos Auth](https://atmos.tools/cli/auth) for authentication and [Atmos Functions](https://atmos.tools/core-concepts/stacks/templates/functions) for dynamic values, eliminating the need for `account-map` entirely.
+The `account-map` component has been deprecated. The reference architecture now uses [Atmos Auth](https://atmos.tools/cli/configuration/auth) for authentication and [Atmos Functions](https://atmos.tools/core-concepts/stacks/templates/functions) for dynamic values, eliminating the need for `account-map` entirely.
 </Intro>
 
 ## Why Deprecate Account Map?
@@ -55,7 +55,7 @@ If you have an existing deployment using the `account-map` component, see the mi
 ## See Also
 
 <Steps>
-1. [Atmos Auth](https://atmos.tools/cli/auth) — Authentication commands
+1. [Atmos Auth](https://atmos.tools/cli/configuration/auth) — Authentication commands
 1. [Atmos Functions](https://atmos.tools/core-concepts/stacks/templates/functions) — Dynamic value resolution
 1. [Identity Layer](/layers/identity/) — IAM Identity Center and access management
 </Steps>

--- a/docs/layers/project/tutorials/migrate-from-account-map.mdx
+++ b/docs/layers/project/tutorials/migrate-from-account-map.mdx
@@ -23,7 +23,7 @@ The `account-map` component is being deprecated in favor of a simpler approach t
 
 <Steps>
 1. Stores account configuration directly in Atmos stack variables
-1. Uses [Atmos Auth](https://atmos.tools/cli/auth) for authentication before Terraform runs
+1. Uses [Atmos Auth](https://atmos.tools/cli/configuration/auth) for authentication before Terraform runs
 1. Uses [Atmos Functions](https://atmos.tools/core-concepts/stacks/templates/functions) for dynamic value resolution
 1. Enables brownfield adoption where accounts already exist
 </Steps>
@@ -284,7 +284,7 @@ This migration path is still being refined. For assistance:
 
 <Steps>
 1. [Legacy Account Map](/layers/accounts/tutorials/legacy-account-map/) — Why account-map was deprecated
-1. [Atmos Auth](https://atmos.tools/cli/auth) — Authentication commands
+1. [Atmos Auth](https://atmos.tools/cli/configuration/auth) — Authentication commands
 1. [Atmos Functions](https://atmos.tools/core-concepts/stacks/templates/functions) — Dynamic value resolution
 1. [IAM Identity Center](/layers/identity/aws-sso/) — Permission Sets configuration
 </Steps>

--- a/internal/prd/deprecate-account-map.md
+++ b/internal/prd/deprecate-account-map.md
@@ -509,4 +509,4 @@ Note: GitOps pages remain accessible via direct URL but are removed from the sid
 
 - [refarch-scaffold PR #818](https://github.com/cloudposse/refarch-scaffold/pull/818) - Implementation PR
 - [refarch-scaffold PRD](https://github.com/cloudposse/refarch-scaffold/blob/upstream-account-map-less/docs/prd/remove-account-map.md) - Original PRD
-- [Atmos Auth Documentation](https://atmos.tools/cli/auth/) - Atmos auth reference
+- [Atmos Auth Documentation](https://atmos.tools/cli/configuration/auth/) - Atmos auth reference


### PR DESCRIPTION
## what
* Fix broken `atmos.tools/cli/auth` links across blog post, docs, and PRD
* Updated all 8 occurrences to the correct URL: `atmos.tools/cli/configuration/auth`

## why
* The Atmos Auth documentation moved from `/cli/auth` to `/cli/configuration/auth`
* Links on the live blog post and docs pages were returning 404s

## references
* https://docs.cloudposse.com/blog/nextgen-component-migration/
* https://atmos.tools/cli/configuration/auth